### PR TITLE
Use small caps for Coq, CoqIDE, and Gallina

### DIFF
--- a/doc/sphinx/MIGRATING
+++ b/doc/sphinx/MIGRATING
@@ -148,7 +148,9 @@ placeholder .rst files for each chapter.
 
     .. include:: replaces.rst
 
-  to gain access to those definitions in your file (you might need a path prefix).
+  to gain access to those definitions in your file (you might need a path prefix). Three especially-important
+  replacements are |Coq|, |CoqIDE|, and |Gallina|, which display those names in small-caps. Please use them,
+  so that they're rendered consistently.
 
   Similarly, there are some LaTeX macros in preamble.rst that can be useful.
 

--- a/doc/sphinx/MIGRATING
+++ b/doc/sphinx/MIGRATING
@@ -148,8 +148,8 @@ placeholder .rst files for each chapter.
 
     .. include:: replaces.rst
 
-  to gain access to those definitions in your file (you might need a path prefix). Three especially-important
-  replacements are |Coq|, |CoqIDE|, and |Gallina|, which display those names in small-caps. Please use them,
+  to gain access to those definitions in your file (you might need a path prefix). Some especially-important
+  replacements are |Cic|, |Coq|, |CoqIDE|, and |Gallina|, which display those names in small-caps. Please use them,
   so that they're rendered consistently.
 
   Similarly, there are some LaTeX macros in preamble.rst that can be useful.

--- a/doc/sphinx/_static/fonts.css
+++ b/doc/sphinx/_static/fonts.css
@@ -1,0 +1,5 @@
+/* rules for associating fonts with Sphinx roles */
+
+.smallcaps {
+    font-variant: small-caps;
+}

--- a/doc/sphinx/addendum/canonical-structures.rst
+++ b/doc/sphinx/addendum/canonical-structures.rst
@@ -1,4 +1,4 @@
-.. _implicitcoercions:
+.. _canonicalstructures:
 
 -----------------------
  Canonical Structures

--- a/doc/sphinx/addendum/extended-pattern-matching.rst
+++ b/doc/sphinx/addendum/extended-pattern-matching.rst
@@ -1,3 +1,5 @@
+.. include:: ../replaces.rst
+
 .. _extendedpatternmatching:
 
 ==================================================
@@ -13,7 +15,7 @@
 
 .. TODO links to figures
 
-This section describes the full form of pattern-matching in Coq terms.
+This section describes the full form of pattern-matching in |Coq| terms.
 
 .. |rhs| replace:: right hand side
 

--- a/doc/sphinx/addendum/parallel-proof-processing.rst
+++ b/doc/sphinx/addendum/parallel-proof-processing.rst
@@ -1,3 +1,5 @@
+.. include:: ../replaces.rst
+
 .. _asynchronousandparallelproofprocessing:
 
 :Source: https://coq.inria.fr/distrib/current/refman/async-proofs.html
@@ -9,8 +11,8 @@ Asynchronous and Parallel Proof Processing
 Author: Enrico Tassi
 
 This chapter explains how proofs can be asynchronously processed by
-Coq. This feature improves the reactivity of the system when used in
-interactive mode via CoqIDE. In addition, it allows Coq to take
+|Coq|. This feature improves the reactivity of the system when used in
+interactive mode via |CoqIDE|. In addition, it allows |Coq| to take
 advantage of parallel hardware when used as a batch compiler by
 decoupling the checking of statements and definitions from the
 construction and checking of proofs objects.
@@ -23,13 +25,13 @@ This feature has some technical limitations that may make it
 unsuitable for some use cases.
 
 For example, in interactive mode, some errors coming from the kernel
-of Coq are signaled late. The type of errors belonging to this
+of |Coq| are signaled late. The type of errors belonging to this
 category are universe inconsistencies.
 
 At the time of writing, only opaque proofs (ending with ``Qed`` or
 ``Admitted``) can be processed asynchronously.
 
-Finally, asynchronous processing is disabled when running CoqIDE in
+Finally, asynchronous processing is disabled when running |CoqIDE| in
 Windows. The current implementation of the feature is not stable on
 Windows. It can be enabled, as described below at :ref:`interactive-mode`,
 though doing so is not recommended.
@@ -37,12 +39,12 @@ though doing so is not recommended.
 Proof annotations
 ----------------------
 
-To process a proof asynchronously Coq needs to know the precise
+To process a proof asynchronously |Coq| needs to know the precise
 statement of the theorem without looking at the proof. This requires
 some annotations if the theorem is proved inside a Section (see
 Section :ref:`TODO-2.4`).
 
-When a section ends, Coq looks at the proof object to decide which
+When a section ends, |Coq| looks at the proof object to decide which
 section variables are actually used and hence have to be quantified in
 the statement of the theorem. To avoid making the construction of
 proofs mandatory when ending a section, one can start each proof with
@@ -61,7 +63,7 @@ variables used.
 Automatic suggestion of proof annotations
 `````````````````````````````````````````
 
-The command ``Set Suggest Proof Using`` makes Coq suggest, when a ``Qed``
+The command ``Set Suggest Proof Using`` makes |Coq| suggest, when a ``Qed``
 command is processed, a correct proof annotation. It is up to the user
 to modify the proof script accordingly.
 
@@ -69,17 +71,17 @@ to modify the proof script accordingly.
 Proof blocks and error resilience
 --------------------------------------
 
-Coq 8.6 introduced a mechanism for error resiliency: in interactive
-mode Coq is able to completely check a document containing errors
+|Coq| 8.6 introduced a mechanism for error resiliency: in interactive
+mode |Coq| is able to completely check a document containing errors
 instead of bailing out at the first failure.
 
 Two kind of errors are supported: errors occurring in vernacular
 commands and errors occurring in proofs.
 
-To properly recover from a failing tactic, Coq needs to recognize the
+To properly recover from a failing tactic, |Coq| needs to recognize the
 structure of the proof in order to confine the error to a sub proof.
 Proof block detection is performed by looking at the syntax of the
-proof script (i.e. also looking at indentation). Coq comes with four
+proof script (i.e. also looking at indentation). |Coq| comes with four
 kind of proof blocks, and an ML API to add new ones.
 
 :curly: blocks are delimited by { and }, see Chapter :ref:`proofhandling`
@@ -95,13 +97,13 @@ Caveats
 When a vernacular command fails the subsequent error messages may be
 bogus, i.e. caused by the first error. Error resiliency for vernacular
 commands can be switched off by passing ``-async-proofs-command-error-resilience off``
-to CoqIDE.
+to |CoqIDE|.
 
 An incorrect proof block detection can result into an incorrect error
 recovery and hence in bogus errors. Proof block detection cannot be
 precise for bullets or any other non well parenthesized proof
 structure. Error resiliency can be turned off or selectively activated
-for any set of block kind passing to CoqIDE one of the following
+for any set of block kind passing to |CoqIDE| one of the following
 options:
 
 - ``-async-proofs-tactic-error-resilience off``
@@ -116,13 +118,13 @@ Interactive mode
 ---------------------
 
 At the time of writing the only user interface supporting asynchronous
-proof processing is CoqIDE.
+proof processing is |CoqIDE|.
 
-When CoqIDE is started, two Coq processes are created. The master one
+When |CoqIDE| is started, two |Coq| processes are created. The master one
 follows the user, giving feedback as soon as possible by skipping
 proofs, which are delegated to the worker process. The worker process,
 whose state can be seen by clicking on the button in the lower right
-corner of the main CoqIDE window, asynchronously processes the proofs.
+corner of the main |CoqIDE| window, asynchronously processes the proofs.
 If a proof contains an error, it is reported in red in the label of
 the very same button, that can also be used to see the list of errors
 and jump to the corresponding line.
@@ -139,14 +141,14 @@ with the gears. Only then are all the universe constraints checked.
 Caveats
 ```````
 
-The number of worker processes can be increased by passing CoqIDE
+The number of worker processes can be increased by passing |CoqIDE|
 the ``-async-proofs-j n`` flag. Note that the memory consumption increases too,
 since each worker requires the same amount of memory as the master
 process. Also note that increasing the number of workers may reduce
 the reactivity of the master process to user commands.
 
 To disable this feature, one can pass the ``-async-proofs off`` flag to
-CoqIDE. Conversely, on Windows, where the feature is disabled by
+|CoqIDE|. Conversely, on Windows, where the feature is disabled by
 default, pass the ``-async-proofs on`` flag to enable it.
 
 Proofs that are known to take little time to process are not delegated
@@ -156,10 +158,10 @@ to a worker process. The threshold can be configure with
 Batch mode
 ---------------
 
-When Coq is used as a batch compiler by running `coqc` or `coqtop`
+When |Coq| is used as a batch compiler by running `coqc` or `coqtop`
 -compile, it produces a `.vo` file for each `.v` file. A `.vo` file contains,
 among other things, theorems statements and proofs. Hence to produce a
-.vo Coq need to process all the proofs of the `.v` file.
+.vo |Coq| need to process all the proofs of the `.v` file.
 
 The asynchronous processing of proofs can decouple the generation of a
 compiled file (like the `.vo` one) that can be loaded by ``Require`` from the
@@ -214,7 +216,7 @@ heavy use of the `Type` hierarchy.
 Limiting the number of parallel workers
 --------------------------------------------
 
-Many Coq processes may run on the same computer, and each of them may
+Many |Coq| processes may run on the same computer, and each of them may
 start many additional worker processes. The `coqworkmgr` utility lets
 one limit the number of workers, globally.
 
@@ -222,9 +224,9 @@ The utility accepts the ``-j`` argument to specify the maximum number of
 workers (defaults to 2). `coqworkmgr` automatically starts in the
 background and prints an environment variable assignment
 like ``COQWORKMGR_SOCKET=localhost:45634``. The user must set this variable
-in all the shells from which Coq processes will be started. If one
+in all the shells from which |Coq| processes will be started. If one
 uses just one terminal running the bash shell, then
 ``export ‘coqworkmgr -j 4‘`` will do the job.
 
-After that, all Coq processes, e.g. `coqide` and `coqc`, will honor the
+After that, all |Coq| processes, e.g. `coqide` and `coqc`, will honor the
 limit, globally.

--- a/doc/sphinx/addendum/program.rst
+++ b/doc/sphinx/addendum/program.rst
@@ -14,25 +14,25 @@ Program
    :local:
 
 We present here the |Program| tactic commands, used to build
-certified Coq programs, elaborating them from their algorithmic
+certified |Coq| programs, elaborating them from their algorithmic
 skeleton and a rich specification :cite:`p-sozeau06`. It can be thought of as a
 dual of :ref:`Extraction <extraction>`. The goal of |Program| is to
 program as in a regular functional programming language whilst using
 as rich a specification as desired and proving that the code meets the
-specification using the whole Coq proof apparatus. This is done using
+specification using the whole |Coq| proof apparatus. This is done using
 a technique originating from the “Predicate subtyping” mechanism of
 PVS :cite:`p-Rushby98`, which generates type-checking conditions while typing a
 term constrained to a particular type. Here we insert existential
 variables in the term, which must be filled with proofs to get a
-complete Coq term. |Program| replaces the |Program| tactic by Catherine
+complete |Coq| term. |Program| replaces the |Program| tactic by Catherine
 Parent :cite:`p-Parent95b` which had a similar goal but is no longer maintained.
 
-The languages available as input are currently restricted to Coq’s
-term language, but may be extended to Objective Caml, Haskell and
-others in the future. We use the same syntax as Coq and permit to use
+The languages available as input are currently restricted to |Coq|’s
+term language, but may be extended to OCaml, Haskell and
+others in the future. We use the same syntax as |Coq| and permit to use
 implicit arguments and the existing coercion mechanism. Input terms
 and types are typed in an extended system (Russell) and interpreted
-into Coq terms. The interpretation process may produce some proof
+into |Coq| terms. The interpretation process may produce some proof
 obligations which need to be resolved to create the final term.
 
 
@@ -41,7 +41,7 @@ obligations which need to be resolved to create the final term.
 Elaborating programs
 ====================
 
-The main difference from Coq is that an object in a type T : Set can
+The main difference from |Coq| is that an object in a type T : Set can
 be considered as an object of type { x : T | P} for any wellformed P :
 Prop. If we go from T to the subset of T verifying property P, we must
 prove that the object under consideration verifies it. Russell will
@@ -92,7 +92,7 @@ coercions.
    This deactivates the special treatment of
    pattern-matching generating equalities and inequalities when using
    |Program| (it is on by default). All pattern-matchings and let-patterns
-   are handled using the standard algorithm of Coq (see :ref:`extended-pattern-matching`)
+   are handled using the standard algorithm of |Coq| (see :ref:`extended-pattern-matching`)
    when this option is deactivated.
 
 .. cmd:: Unset Program Generalized Coercion
@@ -109,7 +109,7 @@ Syntactic control over equalities
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To give more control over the generation of equalities, the
-typechecker will fall back directly to Coq’s usual typing of dependent
+typechecker will fall back directly to |Coq|’s usual typing of dependent
 pattern-matching if a return or in clause is specified. Likewise, the
 if construct is not treated specially by |Program| so boolean tests in
 the code are not automatically reflected in the obligations. One can
@@ -154,15 +154,15 @@ Program Definition
 
    This command types the value term in Russell and generates proof
    obligations. Once solved using the commands shown below, it binds the
-   final Coq term to the name ``ident`` in the environment.
+   final |Coq| term to the name ``ident`` in the environment.
 
    .. exn:: ident already exists
 
    .. cmdv:: Program Definition @ident : @type := @term
 
       It interprets the type ``type``, potentially generating proof
-      obligations to be resolved. Once done with them, we have a Coq
-      type |type_0|. It then elaborates the preterm ``term`` into a Coq
+      obligations to be resolved. Once done with them, we have a |Coq|
+      type |type_0|. It then elaborates the preterm ``term`` into a |Coq|
       term |term_0|, checking that the type of |term_0| is coercible to
       |type_0|, and registers ``ident`` as being of type |type_0| once the
       set of obligations generated during the interpretation of |term_0|
@@ -200,7 +200,7 @@ The optional order annotation follows the grammar:
 
 + :g:`wf R x` which is equivalent to :g:`measure x (R)`.
 
-The structural fixpoint operator behaves just like the one of Coq (see
+The structural fixpoint operator behaves just like the one of |Coq| (see
 Section `TODO-1.3.4-Fixpoint`_), except it may also generate obligations. It works
 with mutually recursive definitions too.
 
@@ -356,7 +356,7 @@ Frequently Asked Questions
 .. exn:: Ill-formed recursive definition
 
   This error can happen when one tries to define a function by structural
-  recursion on a subset object, which means the Coq function looks like:
+  recursion on a subset object, which means the |Coq| function looks like:
 
   ::
 

--- a/doc/sphinx/addendum/program.rst
+++ b/doc/sphinx/addendum/program.rst
@@ -1,6 +1,8 @@
-.. _program:
-
 .. include:: ../replaces.rst
+
+.. this should be just "_program", but refs to it don't work
+
+.. _programs:
 
 ----------
 Program

--- a/doc/sphinx/addendum/universe-polymorphism.rst
+++ b/doc/sphinx/addendum/universe-polymorphism.rst
@@ -1,3 +1,5 @@
+.. include:: ../replaces.rst
+
 .. _polymorphicuniverses:
 
 ==================================
@@ -18,7 +20,7 @@ General Presentation
 
    The status of Universe Polymorphism is experimental.
 
-This section describes the universe polymorphic extension of Coq.
+This section describes the universe polymorphic extension of |Coq|.
 Universe polymorphism makes it possible to write generic definitions
 making use of universes and reuse them at different and sometimes
 incompatible universe levels.

--- a/doc/sphinx/language/coq-library.rst
+++ b/doc/sphinx/language/coq-library.rst
@@ -1,7 +1,9 @@
+.. include:: ../replaces.rst
+
 .. _thecoqlibrary:
 
 -----------------
- The Coq library
+The |Coq| library
 -----------------
 
 :Source: https://coq.inria.fr/distrib/current/refman/stdlib.html

--- a/doc/sphinx/language/gallina-extensions.rst
+++ b/doc/sphinx/language/gallina-extensions.rst
@@ -1,16 +1,13 @@
-.. include:: ../preamble.rst
 .. include:: ../replaces.rst
 
-.. Gallina should be in small-caps, maybe create a role for that
-
-Extensions of Gallina
-=====================
+Extensions of |Gallina|
+=======================
 
 :Source: https://coq.inria.fr/distrib/current/refman/gallina-ext.html
 :Converted by: Paul Steckler
 
-Gallina is the kernel language of Coq. We describe here extensions of
-Gallina’s syntax.
+|Gallina| is the kernel language of |Coq|. We describe here extensions of
+|Gallina|’s syntax.
 
 Record types
 ----------------
@@ -467,17 +464,17 @@ Printing nested patterns
 The Calculus of Inductive Constructions knows pattern-matching only
 over simple patterns. It is however convenient to re-factorize nested
 pattern-matching into a single pattern-matching over a nested
-pattern. Coq’s printer tries to do such limited re-factorization.
+pattern. |Coq|’s printer tries to do such limited re-factorization.
 
 .. cmd:: Set Printing Matching.
 
-This tells Coq to try to use nested patterns. This is the default
+This tells |Coq| to try to use nested patterns. This is the default
 behavior.
 
 .. cmd:: Unset Printing Matching.
 
-This tells Coq to print only simple pattern-matching problems in the
-same way as the Coq kernel handles them.
+This tells |Coq| to print only simple pattern-matching problems in the
+same way as the |Coq| kernel handles them.
 
 .. cmd:: Test Printing Matching.
 
@@ -518,7 +515,7 @@ depend of the matched term.
 
 .. cmd:: Set Printing Synth.
 
-The result type is not printed when Coq knows that it can re-
+The result type is not printed when |Coq| knows that it can re-
 synthesize it.
 
 .. cmd:: Unset Printing Synth.
@@ -1244,17 +1241,17 @@ Libraries and qualified names
 Names of libraries
 ~~~~~~~~~~~~~~~~~~
 
-The theories developed in Coq are stored in *library files* which are
+The theories developed in |Coq| are stored in *library files* which are
 hierarchically classified into *libraries* and *sublibraries*. To
 express this hierarchy, library names are represented by qualified
 identifiers qualid, i.e. as list of identifiers separated by dots (see
 :ref:`TODO-1.2.3-identifiers`). For instance, the library file ``Mult`` of the standard
-Coq library ``Arith`` is named ``Coq.Arith.Mult``. The identifier that starts
+|Coq| library ``Arith`` is named ``Coq.Arith.Mult``. The identifier that starts
 the name of a library is called a *library root*. All library files of
-the standard library of Coq have the reserved root Coq but library
-file names based on other roots can be obtained by usingCoq commands
+the standard library of |Coq| have the reserved root |Coq| but library
+file names based on other roots can be obtained by using |Coq| commands
 (coqc, coqtop, coqdep, …) options ``-Q`` or ``-R`` (see :ref:`TODO-14.3.3-command-line-options`).
-Also, when an interactive Coq session starts, a library of root ``Top`` is
+Also, when an interactive |Coq| session starts, a library of root ``Top`` is
 started, unless option ``-top`` or ``-notop`` is set (see :ref:`TODO-14.3.3-command-line-options`).
 
 
@@ -1270,7 +1267,7 @@ followed by the sequence of submodules names encapsulating the
 construction and ended by the proper name of the construction.
 Typically, the absolute name ``Coq.Init.Logic.eq`` denotes Leibniz’
 equality defined in the module Logic in the sublibrary ``Init`` of the
-standard library of Coq.
+standard library of |Coq|.
 
 The proper name that ends the name of a construction is the short name
 (or sometimes base name) of the construction (for instance, the short
@@ -1279,7 +1276,7 @@ name is a *partially qualified name* (e.g. ``Logic.eq`` is a partially
 qualified name for ``Coq.Init.Logic.eq``). Especially, the short name of a
 construction is its shortest partially qualified name.
 
-Coq does not accept two constructions (definition, theorem, …) with
+|Coq| does not accept two constructions (definition, theorem, …) with
 the same absolute name but different constructions can have the same
 short name (or even same partially qualified names as soon as the full
 names are different).
@@ -1289,14 +1286,14 @@ names also applies to library file names.
 
 **Visibility**
 
-Coq maintains a table called the name table which maps partially qualified
+|Coq| maintains a table called the name table which maps partially qualified
 names of constructions to absolute names. This table is updated by the
 commands ``Require`` (see :ref:`TODO-6.5.1-Require`), Import and Export (see :ref:`import_qualid`) and
 also each time a new declaration is added to the context. An absolute
 name is called visible from a given short or partially qualified name
 when this latter name is enough to denote it. This means that the
 short or partially qualified name is mapped to the absolute name in
-Coq name table. Definitions flagged as Local are only accessible with
+|Coq| name table. Definitions flagged as Local are only accessible with
 their fully qualified name (see :ref:`TODO-1.3.2-definitions`).
 
 It may happen that a visible name is hidden by the short name or a
@@ -1327,13 +1324,13 @@ Libraries and filesystem
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 Please note that the questions described here have been subject to
-redesign in Coq v8.5. Former versions of Coq use the same terminology
+redesign in |Coq| v8.5. Former versions of |Coq| use the same terminology
 to describe slightly different things.
 
 Compiled files (``.vo`` and ``.vio``) store sub-libraries. In order to refer
-to them inside Coq, a translation from file-system names to Coq names
+to them inside |Coq|, a translation from file-system names to |Coq| names
 is needed. In this translation, names in the file system are called
-*physical* paths while Coq names are contrastingly called *logical*
+*physical* paths while |Coq| names are contrastingly called *logical*
 names.
 
 A logical prefix Lib can be associated to a physical pathpath using
@@ -1341,7 +1338,7 @@ the command line option ``-Q`` `path` ``Lib``. All subfolders of path are
 recursively associated to the logical path ``Lib`` extended with the
 corresponding suffix coming from the physical path. For instance, the
 folder ``path/fOO/Bar`` maps to ``Lib.fOO.Bar``. Subdirectories corresponding
-to invalid Coq identifiers are skipped, and, by convention,
+to invalid |Coq| identifiers are skipped, and, by convention,
 subdirectories named ``CVS`` or ``_darcs`` are skipped too.
 
 Thanks to this mechanism, .vo files are made available through the
@@ -1353,7 +1350,7 @@ its logical name, so that an error is issued if it is loaded with the
 wrong loadpath afterwards.
 
 Some folders have a special status and are automatically put in the
-path.Coq commands associate automatically a logical path to files in
+path. |Coq| commands associate automatically a logical path to files in
 the repository trees rooted at the directory from where the command is
 launched, coqlib/user-contrib/, the directories listed in the
 `$COQPATH`, `${XDG_DATA_HOME}/coq/` and `${XDG_DATA_DIRS}/coq/`
@@ -1375,14 +1372,14 @@ of the ``Require`` command can be used to bypass the implicit shortening
 by providing an absolute root to the required file (see :ref:`TODO-6.5.1-require-qualid`).
 
 There also exists another independent loadpath mechanism attached to
-OCaml object files (``.cmo`` or ``.cmxs``) rather than Coq object
+OCaml object files (``.cmo`` or ``.cmxs``) rather than |Coq| object
 files as described above. The OCaml loadpath is managed using
 the option ``-I`` `path` (in the OCaml world, there is neither a
 notion of logical name prefix nor a way to access files in
 subdirectories of path). See the command ``Declare`` ``ML`` ``Module`` in
 :ref:`TODO-6.5-compiled-files` to understand the need of the OCaml loadpath.
 
-See :ref:`TODO-14.3.3-command-line-options` for a more general view over the Coq command
+See :ref:`TODO-14.3.3-command-line-options` for a more general view over the |Coq| command
 line options.
 
 
@@ -1516,7 +1513,7 @@ possible, the correct argument will be automatically generated.
 
 .. exn:: Cannot infer a term for this placeholder.
 
-   Coq was not able to deduce an instantiation of a “_”.
+   |Coq| was not able to deduce an instantiation of a “_”.
 
 .. _declare-implicit-args:
 
@@ -1525,7 +1522,7 @@ Declaration of implicit arguments
 
 In case one wants that some arguments of a given object (constant,
 inductive types, constructors, assumptions, local or not) are always
-inferred by Coq, one may declare once and for all which are the
+inferred by |Coq|, one may declare once and for all which are the
 expected implicit arguments of this object. There are two ways to do
 this, *a priori* and *a posteriori*.
 
@@ -1654,7 +1651,7 @@ command ``Print Implicit`` (see :ref:`displaying-implicit-args`).
 Automatic declaration of implicit arguments
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Coq can also automatically detect what are the implicit arguments of a
+|Coq| can also automatically detect what are the implicit arguments of a
 defined object. The command is just
 
 .. cmd:: Arguments @qualid : default implicits.
@@ -1768,7 +1765,7 @@ command
 Conversely, use the command ``Unset Strongly Strict Implicit`` to let the
 option “Strict Implicit” decide what to do.
 
-Remark: In versions of Coq prior to version 8.0, the default was to
+Remark: In versions of |Coq| prior to version 8.0, the default was to
 declare the strict implicit arguments as implicit.
 
 .. _controlling-contextual-implicit-args:
@@ -1776,8 +1773,8 @@ declare the strict implicit arguments as implicit.
 Controlling contextual implicit arguments
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-By default, Coq does not automatically set implicit the contextual
-implicit arguments. To tell Coq to infer also contextual implicit
+By default, |Coq| does not automatically set implicit the contextual
+implicit arguments. To tell |Coq| to infer also contextual implicit
 argument, use command
 
 .. cmd:: Set Contextual Implicit.
@@ -1790,8 +1787,8 @@ contextual implicit mode.
 Controlling reversible-pattern implicit arguments
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-By default, Coq does not automatically set implicit the reversible-pattern
-implicit arguments. To tell Coq to infer also reversible-
+By default, |Coq| does not automatically set implicit the reversible-pattern
+implicit arguments. To tell |Coq| to infer also reversible-
 pattern implicit argument, use command
 
 .. cmd:: Set Reversible Pattern Implicit.
@@ -2206,7 +2203,7 @@ unspecified if `string` doesn’t end in ``.dot`` or ``.gv``.
 Existential variables
 ---------------------
 
-Coq terms can include existential variables which represents unknown
+|Coq| terms can include existential variables which represents unknown
 subterms to eventually be replaced by actual subterms.
 
 Existential variables are generated in place of unsolvable implicit

--- a/doc/sphinx/language/gallina-extensions.rst
+++ b/doc/sphinx/language/gallina-extensions.rst
@@ -1,5 +1,7 @@
 .. include:: ../replaces.rst
 
+.. _extensionsofgallina:
+
 Extensions of |Gallina|
 =======================
 
@@ -89,7 +91,7 @@ To build an object of type `ident`, one should provide the constructor
 Alternatively, the following syntax allows creating objects by using named fields, as
 shown in this grammar. The fields do not have to be in any particular order, nor do they have
 to be all present if the missing ones can be inferred or prompted for
-(see Chapter :ref:`TODO-24-Programs`).
+(see :ref:`programs`).
 
 .. coqtop:: all
 
@@ -1948,7 +1950,7 @@ A canonical structure is an instance of a record/structure type that
 can be used to solve unification problems involving a projection
 applied to an unknown structure instance (an implicit argument) and a
 value. The complete documentation of canonical structures can be found
-in Chapter :ref:`TODO-19-canonical-structures`; here only a simple example is given.
+in :ref:`canonicalstructures`; here only a simple example is given.
 
 Assume that `qualid` denotes an object ``(Build_struc`` |c_1| … |c_n| ``)`` in the
 structure *struct* of which the fields are |x_1|, …, |x_n|. Assume that
@@ -2142,7 +2144,7 @@ which declares the construction denoted by qualid as a coercion
 between the two given classes.
 
 More details and examples, and a description of the commands related
-to coercions are provided in Chapter :ref:`TODO-18-implicit coercions`.
+to coercions are provided in :ref:`implicitcoercions`.
 
 .. _printing_constructions_full:
 
@@ -2150,7 +2152,7 @@ Printing constructions in full
 ------------------------------
 
 Coercions, implicit arguments, the type of pattern-matching, but also
-notations (see Chapter :ref:`TODO-12-interpretation-scopes`) can obfuscate the behavior of some
+notations (see :ref:`syntaxextensionsandinterpretationscopes`) can obfuscate the behavior of some
 tactics (typically the tactics applying to occurrences of subterms are
 sensitive to the implicit arguments). The command
 
@@ -2286,7 +2288,7 @@ is not specified and is implementation-dependent. The inner tactic may
 use any variable defined in its scope, including repeated alternations
 between variables introduced by term binding as well as those
 introduced by tactic binding. The expression `tacexpr` can be any tactic
-expression as described in Chapter :ref:`TODO-9-ltac`.
+expression as described in :ref:`thetacticlanguage`.
 
 .. coqtop:: all
 

--- a/doc/sphinx/practical-tools/coq-commands.rst
+++ b/doc/sphinx/practical-tools/coq-commands.rst
@@ -1,17 +1,19 @@
+.. include:: ../replaces.rst
+
 .. _thecoqcommands:
 
 -------------------
- The Coq commands
+ The |Coq| commands
 -------------------
 
 :Source: https://coq.inria.fr/distrib/current/refman/commands.html
 :Converted by: Paul Steckler
 
-There are three Coq commands:
+There are three |Coq| commands:
 
-+ `coqtop`: the Coq toplevel (interactive mode);
-+ `coqc`: the Coq compiler (batch compilation);
-+ `coqchk`: the Coq checker (validation of compiled libraries).
++ `coqtop`: the |Coq| toplevel (interactive mode);
++ `coqc`: the |Coq| compiler (batch compilation);
++ `coqchk`: the |Coq| checker (validation of compiled libraries).
 
 
 The options are (basically) the same for the first two commands, and
@@ -21,11 +23,11 @@ roughly described below. You can also look at the `man` pages of
 Interactive use (coqtop)
 ------------------------
 
-In the interactive mode, also known as the Coq toplevel, the user can
-develop his theories and proofs step by step. The Coq toplevel is run
+In the interactive mode, also known as the |Coq| toplevel, the user can
+develop his theories and proofs step by step. The |Coq| toplevel is run
 by the command `coqtop`.
 
-They are two different binary images of Coq: the byte-code one and the
+They are two different binary images of |Coq|: the byte-code one and the
 native-code one (if OCaml provides a native-code compiler for
 your platform, which is supposed in the following). By default,
 `coqtop` executes the native-code version; run `coqtop.byte` to get
@@ -33,7 +35,7 @@ the byte-code version.
 
 The byte-code toplevel is based on an OCaml toplevel (to
 allow dynamic linking of tactics). You can switch to the OCaml toplevel
-with the command `Drop.`, and come back to theCoq
+with the command `Drop.`, and come back to the |Coq|
 toplevel with the command `Coqloop.loop();;`.
 
 Batch compilation (coqc)
@@ -42,7 +44,7 @@ Batch compilation (coqc)
 The `coqc` command takes a name *file* as argument. Then it looks for a
 vernacular file named *file*.v, and tries to compile it into a
 *file*.vo file (See :ref:`TODO-6.5`). Warning: The name *file* should be a
-regular Coq identifier, as defined in Section :ref:'TODO-1.1'. It should contain
+regular |Coq| identifier, as defined in Section :ref:'TODO-1.1'. It should contain
 only letters, digits or underscores (_). For instance, `/bar/foo/toto.v` is valid, but
 `/bar/foo/to-to.v` is invalid.
 
@@ -53,7 +55,7 @@ Customization at launch time
 By resource file
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-When Coq is launched, with either `coqtop` or `coqc`, the resource file
+When |Coq| is launched, with either `coqtop` or `coqc`, the resource file
 `$XDG_CONFIG_HOME/coq/coqrc.xxx` is loaded, where `$XDG_CONFIG_HOME`
 is the configuration directory of the user (by default its home
 directory `/.config` and `xxx` is the version number (e.g. 8.8). If
@@ -62,19 +64,19 @@ searched. You can also specify an arbitrary name for the resource file
 (see option `-init-file` below).
 
 This file may contain, for instance, `Add LoadPath` commands to add
-directories to the load path of Coq. It is possible to skip the
+directories to the load path of |Coq|. It is possible to skip the
 loading of the resource file with the option `-q`.
 
 
 14.3.2 By environment variables
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Load path can be specified to the Coq system by setting up `$COQPATH`
+Load path can be specified to the |Coq| system by setting up `$COQPATH`
 environment variable. It is a list of directories separated by
-`:` (`;` on Windows). Coq will also honor `$XDG_DATA_HOME` and
+`:` (`;` on Windows). |Coq| will also honor `$XDG_DATA_HOME` and
 `$XDG_DATA_DIRS` (see Section :ref:`TODO-2.6.3`).
 
-Some Coq commands call other Coq commands. In this case, they look for
+Some |Coq| commands call other |Coq| commands. In this case, they look for
 the commands in directory specified by `$COQBIN`. If this variable is
 not set, they look for the commands in the executable path.
 
@@ -96,21 +98,21 @@ and `coqtop`, unless stated otherwise:
   to the OCaml loadpath. See also: :ref:`TODO-2.6.1` and the
   command Declare ML Module Section :ref:`TODO-6.5`.
 :-Q *directory* dirpath: Add physical path *directory* to the list of
-  directories whereCoq looks for a file and bind it to the the logical
+  directories where |Coq| looks for a file and bind it to the the logical
   directory *dirpath*. The subdirectory structure of *directory* is
-  recursively available from Coq using absolute names (extending the
+  recursively available from |Coq| using absolute names (extending the
   dirpath prefix) (see Section :ref:`TODO-2.6.2`).Note that only those
   subdirectories and files which obey the lexical conventions of what is
   an ident (see Section :ref:`TODO-1.1`) are taken into account. Conversely, the
   underlying file systems or operating systems may be more restrictive
-  than Coq. While Linux’s ext4 file system supports any Coq recursive
+  than |Coq|. While Linux’s ext4 file system supports any |Coq| recursive
   layout (within the limit of 255 bytes per file name), the default on
   NTFS (Windows) or HFS+ (MacOS X) file systems is on the contrary to
   disallow two files differing only in the case in the same directory.
   See also: Section :ref:`TODO-2.6.1`.
 :-R *directory* dirpath: Do as -Q *directory* dirpath but make the
   subdirectory structure of *directory* recursively visible so that the
-  recursive contents of physical *directory* is available from Coq using
+  recursive contents of physical *directory* is available from |Coq| using
   short or partially qualified names. See also: Section :ref:`TODO-2.6.1`.
 :-top dirpath: Set the toplevel module name to dirpath instead of Top.
   Not valid for `coqc` as the toplevel module name is inferred from the
@@ -127,14 +129,14 @@ and `coqtop`, unless stated otherwise:
 :-q: Do not to load the default resource file.
 :-load-ml-source *file*: Load the OCaml source file *file*.
 :-load-ml-object *file*: Load the OCaml object file *file*.
-:-l *file*, -load-vernac-source *file*: Load and execute the Coq
+:-l *file*, -load-vernac-source *file*: Load and execute the |Coq|
   script from *file.v*.
 :-lv *file*, -load-vernac-source-verbose *file*: Load and execute the
-  Coq script from *file.v*. Output its content on the standard input as
+  |Coq| script from *file.v*. Output its content on the standard input as
   it is executed.
-:-load-vernac-object dirpath: Load Coq compiled library dirpath. This
+:-load-vernac-object dirpath: Load |Coq| compiled library dirpath. This
   is equivalent to runningRequire dirpath.
-:-require dirpath: Load Coq compiled library dirpath and import it.
+:-require dirpath: Load |Coq| compiled library dirpath and import it.
   This is equivalent to running Require Import dirpath.
 :-batch: Exit just after argument parsing. Available for `coqtop` only.
 :-compile *file.v*: Compile file *file.v* into *file.vo*. This options
@@ -149,7 +151,7 @@ and `coqtop`, unless stated otherwise:
   option expects all, none or a comma-separated list of warning names or
   categories (see Section :ref:`TODO-6.9.3`).
 :-with-geoproof (yes|no): Enable or not special functions for Geoproof
-  within CoqIDE (default is yes).
+  within |CoqIDE| (default is yes).
 :-color (on|off|auto): Enable or not the coloring of output of `coqtop`.
   Default is auto, meaning that `coqtop` dynamically decides, depending on
   whether the output channel supports ANSI escape sequences.
@@ -158,11 +160,11 @@ and `coqtop`, unless stated otherwise:
   syntax/definitions/notations.
 :-emacs, -ide-slave: Start a special toplevel to communicate with a
   specific IDE.
-:-impredicative-set: Change the logical theory of Coq by declaring the
+:-impredicative-set: Change the logical theory of |Coq| by declaring the
    sort Set impredicative. Warning: This is known to be inconsistent with some
    standard axioms of classical mathematics such as the functional
    axiom of choice or the principle of description.
-:-type-in-type: Collapse the universe hierarchy of Coq. Warning: This makes the logic
+:-type-in-type: Collapse the universe hierarchy of |Coq|. Warning: This makes the logic
    inconsistent.
 :-compat *version*: Attempt to maintain some backward-compatibility
   with a previous version.
@@ -172,16 +174,16 @@ and `coqtop`, unless stated otherwise:
 :-no-glob: Disable the dumping of references for global names.
 :-image *file*: Set the binary image to be used by `coqc` to be *file*
   instead of the standard one. Not of general use.
-:-bindir *directory*: Set the directory containing Coq binaries to be
+:-bindir *directory*: Set the directory containing |Coq| binaries to be
   used by `coqc`. It is equivalent to doing export COQBIN= *directory*
   before launching `coqc`.
-:-where: Print the location of Coq’s standard library and exit.
-:-config: Print the locations of Coq’s binaries, dependencies, and
+:-where: Print the location of |Coq|’s standard library and exit.
+:-config: Print the locations of |Coq|’s binaries, dependencies, and
   libraries, then exit.
 :-filteropts: Print the list of command line arguments that `coqtop` has
   recognized as options and exit.
-:-v: Print Coq’s version and exit.
-:-list-tags: Print the highlight tags known by Coq as well as their
+:-v: Print |Coq|’s version and exit.
+:-list-tags: Print the highlight tags known by |Coq| as well as their
   currently associated color and exit.
 :-h, --help: Print a short usage and exit.
 

--- a/doc/sphinx/practical-tools/coqide.rst
+++ b/doc/sphinx/practical-tools/coqide.rst
@@ -1,7 +1,9 @@
+.. include:: ../replaces.rst
+
 .. _coqintegrateddevelopmentenvironment:
 
 ----------------------------------------
- Coq Integrated Development Environment
+|Coq| Integrated Development Environment
 ----------------------------------------
 
 :Source: https://coq.inria.fr/distrib/current/refman/coqide.html

--- a/doc/sphinx/replaces.rst
+++ b/doc/sphinx/replaces.rst
@@ -1,5 +1,11 @@
 .. some handy replacements for common items
 
+.. role:: smallcaps
+
+.. |Coq| replace:: :smallcaps:`Coq`
+.. |CoqIDE| replace:: :smallcaps:`CoqIDE`
+.. |Gallina| replace:: :smallcaps:`Gallina`
+
 .. |A_1| replace:: `A`\ :math:`_{1}`
 .. |A_n| replace:: `A`\ :math:`_{n}`
 

--- a/doc/sphinx/replaces.rst
+++ b/doc/sphinx/replaces.rst
@@ -2,6 +2,7 @@
 
 .. role:: smallcaps
 
+.. |Cic| replace:: :smallcaps:`Cic`
 .. |Coq| replace:: :smallcaps:`Coq`
 .. |CoqIDE| replace:: :smallcaps:`CoqIDE`
 .. |Gallina| replace:: :smallcaps:`Gallina`

--- a/doc/tools/coqrst/coqdomain.py
+++ b/doc/tools/coqrst/coqdomain.py
@@ -799,6 +799,7 @@ def setup(app):
 
     # Add extra styles
     app.add_stylesheet("hint.min.css")
+    app.add_stylesheet("fonts.css")
     app.add_stylesheet("ansi.css")
     app.add_stylesheet("coqdoc.css")
     app.add_javascript("notations.js")


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** documentation 

Documentation improvement.

Using |Coq| and |Gallina| puts those names in small-caps. I've made that change in the "Extensions of Gallina" chapter.

