### PR TITLE
Add indexes to TOC

### DIFF
--- a/doc/sphinx/coq-cmdindex.rst
+++ b/doc/sphinx/coq-cmdindex.rst
@@ -1,0 +1,4 @@
+.. hack to get index in TOC
+-----------------
+Command index
+-----------------

--- a/doc/sphinx/coq-exnindex.rst
+++ b/doc/sphinx/coq-exnindex.rst
@@ -1,0 +1,4 @@
+.. hack to get index in TOC
+----------------------
+Errors, warnings index
+----------------------

--- a/doc/sphinx/coq-optindex.rst
+++ b/doc/sphinx/coq-optindex.rst
@@ -1,0 +1,4 @@
+.. hack to get index in TOC
+-----------------
+Option index
+-----------------

--- a/doc/sphinx/coq-tacindex.rst
+++ b/doc/sphinx/coq-tacindex.rst
@@ -1,0 +1,4 @@
+.. hack to get index in TOC
+-------------
+Tactic index
+-------------

--- a/doc/sphinx/genindex.rst
+++ b/doc/sphinx/genindex.rst
@@ -1,0 +1,4 @@
+.. hack to get index in TOC
+-----
+Index
+-----

--- a/doc/sphinx/index.rst
+++ b/doc/sphinx/index.rst
@@ -1,6 +1,6 @@
 .. _introduction:
 
-===========================================
+
 Introduction
 ===========================================
 
@@ -1390,30 +1390,23 @@ Table of contents
    addendum/universe-polymorphism
    addendum/miscellaneous-extensions
 
+.. toctree::
+   :caption: Reference
+   :maxdepth: 10
+	     
    glossary
 
    zebibliography
 
 .. toctree::
-   :caption: Porting to Sphinx
-
-   porting/gallina-specification-language
-   porting/cic
-   porting/tactics
-   porting/tricky-bits
-
-There's also an work-in-progress version of a `PDF manual <http://web.mit.edu/cpitcla/www/coq-rst/Coq85.pdf>`_.
-
---------
-Indexes
---------
-
-* :ref:`genindex`
-* :index:`cmdindex`
-* :index:`tacindex`
-* :index:`optindex`
-* :index:`exnindex`
-* :ref:`search`
-
+   :caption: Indexes
+   :maxdepth: 10
+	     
+   genindex
+   coq-cmdindex
+   coq-tacindex	      
+   coq-optindex	      
+   coq-exnindex	      
+   
 .. No entries yet
   * :index:`thmindex`


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** documentation

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->

<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->

This PR adds the indexes (general, tactics, commands, options, errors/warnings) to the table of contents, so they appear in the navigation sidebar (at the end).

It's a bit experimental, because it uses the hack given at:

  https://stackoverflow.com/questions/40556423/how-can-i-link-the-generated-index-page-in-readthedocs-navigation-bar

Specifically, Sphinx tells you not to use the name `genindex.rst`, and this PR does just that. The hack does work, but we should keep an eye out for problems.

