### PR TITLE
Fixup section levels in Ch 2; document section hierarchy in MIGRATING

### DIFF
--- a/doc/sphinx/MIGRATING
+++ b/doc/sphinx/MIGRATING
@@ -185,6 +185,11 @@ placeholder .rst files for each chapter.
       .. exn:: Something's not right.
       .. warn:: You shouldn't do that.
 
+    - As an alternative to "productionlist" for grammars, you can also use the "prodn" directive,
+      which allows to write a single production, which appears with a blue background in the same
+      way that "cmd" and "tacn" appear. You can use the "{*; foo}" syntax that's used for
+      with those directives.
+
     - Use the "example" directive for examples
 
     - Use the "g" role for inline Gallina, like :g:`fun x => x`
@@ -198,6 +203,30 @@ placeholder .rst files for each chapter.
 ::
 
         your other code here
+
+  Section hierarchy:
+
+    Sections, subsections, and so on, are indicated by underlining phrases. The characters
+    used need to be distinct at each level, though it appears to be not so important what
+    those characters are. For consistency in this project, the suggested characters are:
+
+    Chapter title    HTML H1
+    =============
+
+    Section          HTML H2
+    -------
+
+    Subsection       HTML H3
+    ~~~~~~~~~~
+
+    Subsubsection    HTML H4
+    +++++++++++++
+
+    We shouldn't need to go deeper. Why these particular characters, in this order? They're
+    the first 4 section underline characters mentioned in the default value of
+    "rst-preferred-adornments" in Emacs "ReST mode" (the mode supporting editing of ReStructuredText,
+    the format that Sphinx is based on). It's also possible to use under-and-overlining, which we
+    won't use.
 
 # Making changes to the text
 

--- a/doc/sphinx/language/gallina-extensions.rst
+++ b/doc/sphinx/language/gallina-extensions.rst
@@ -240,7 +240,7 @@ flag. Another compatibility printing can be activated thanks to the
 printing of pattern-matching over primitive records.
 
 Primitive Record Types
-~~~~~~~~~~~~~~~~~~~~~~
+++++++++++++++++++++++
 
 When the ``Set Primitive Projections`` option is on, definitions of
 record types change meaning. When a type is declared with primitive
@@ -271,7 +271,7 @@ There are currently two ways to introduce primitive records types:
    can be defined.
 
 Reduction
-~~~~~~~~~
++++++++++
 
 The basic reduction rule of a primitive projection is
 |p_i| ``(Build_``\ `R` |t_1| … |t_n|\ ``)`` :math:`{\rightarrow_{\iota}}` |t_i|.
@@ -287,7 +287,7 @@ to display unfolded primitive projections as matches and distinguish them from f
 
 
 Compatibility Projections and :g:`match`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+++++++++++++++++++++++++++++++++++++++++
 
 To ease compatibility with ordinary record types, each primitive
 projection is also defined as a ordinary constant taking parameters and
@@ -379,7 +379,7 @@ constructions. There are two variants of them.
 
 
 First destructuring let syntax
-``````````````````````````````
+++++++++++++++++++++++++++++++
 
 The expression :g:`let (`\ |ident_1|:g:`, … ,` |ident_n|\ :g:`) :=` |term_0|\ :g:`in` |term_1| performs
 case analysis on |term_0| which must be in an inductive type with one
@@ -424,7 +424,7 @@ and
 
 
 Second destructuring let syntax
-```````````````````````````````
++++++++++++++++++++++++++++++++
 
 Another destructuring let syntax is available for inductive types with
 one constructor by giving an arbitrary pattern instead of just a tuple
@@ -463,7 +463,7 @@ The following commands give some control over the pretty-printing
 of :g:`match` expressions.
 
 Printing nested patterns
-````````````````````````
++++++++++++++++++++++++++
 
 The Calculus of Inductive Constructions knows pattern-matching only
 over simple patterns. It is however convenient to re-factorize nested
@@ -486,7 +486,7 @@ This tells if the printing matching mode is on or off. The default is
 on.
 
 Printing of wildcard patterns
-`````````````````````````````
+++++++++++++++++++++++++++++++
 
 Some variables in a pattern may not occur in the right-hand side of
 the pattern-matching clause. There are options to control the display
@@ -511,7 +511,7 @@ to print wildcard for useless variables.
 
 
 Printing of the elimination predicate
-`````````````````````````````````````
++++++++++++++++++++++++++++++++++++++
 
 In most of the cases, the type of the result of a matched term is
 mechanically synthesizable. Especially, if the result type does not
@@ -533,7 +533,7 @@ The default is to not print synthesizable types.
 
 
 Printing matching on irrefutable patterns
-`````````````````````````````````````````
+++++++++++++++++++++++++++++++++++++++++++
 
 If an inductive type has just one constructor, pattern-matching can be
 written using the first destructuring let syntax.
@@ -565,7 +565,7 @@ written using the first destructuring let syntax.
 
 
 Printing matching on booleans
-`````````````````````````````
++++++++++++++++++++++++++++++
 
 If an inductive type is isomorphic to the boolean type, pattern-matching
 can be written using ``if`` … ``then`` … ``else`` …:
@@ -1533,7 +1533,7 @@ this, *a priori* and *a posteriori*.
 
 
 Implicit Argument Binders
-`````````````````````````
++++++++++++++++++++++++++
 
 In the first setting, one wants to explicitly give the implicit
 arguments of a declared object as part of its definition. To do this,
@@ -1575,7 +1575,7 @@ usual implicit arguments disambiguation syntax.
 
 
 Declaring Implicit Arguments
-````````````````````````````
+++++++++++++++++++++++++++++
 
 To set implicit arguments *a posteriori*, one can use the command:
 
@@ -2013,7 +2013,7 @@ See also: more examples in user contribution category (Rocq/ALGEBRA).
 
 
 Print Canonical Projections.
-````````````````````````````
+++++++++++++++++++++++++++++
 
 This displays the list of global names that are components of some
 canonical structure. For each of them, the canonical structure of


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

Some of the section hierarchy got collapsed in Ch 2, which I had migrated. I fixed that, and documented how sections/subsections should be marked in the MIGRATING file.

I haven't checked how others did this in their chapters. It's not so important how they marked sections, Sphinx should allow other choices of underline characters. At some point, it would be nice if this were done uniformly across chapters, perhaps during a cleanup phase.

<!-- Keep what applies -->
**Kind:** documentation

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->


<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
