### PR TITLE
Sphinx Reference manual: Alphabetize preamble and replaces. Up coqtop timeout.

### DIFF
--- a/doc/sphinx/MIGRATING
+++ b/doc/sphinx/MIGRATING
@@ -164,6 +164,12 @@ placeholder .rst files for each chapter.
 
   Similarly, there are some LaTeX macros in preamble.rst that can be useful.
 
+  NOTE: replaces.rst and preamble.tst are alphabetized in order to help avoid duplicates
+  and to minimize merge conflicts. They are alphabetized first in a case-insensitive
+  way by the term being defined, and if there are two terms with same case-insensitive
+  spelling, then by the ascii case-sensitive order. If you insert new items please
+  put them in the correct order.
+
   Conventions:
 
     - Keywords and other literal text is double-backquoted (e.g. ``Module``, ``Section``, ``(``, ``,``).

--- a/doc/sphinx/preamble.rst
+++ b/doc/sphinx/preamble.rst
@@ -1,60 +1,57 @@
 .. preamble::
 
    \[
-   \newcommand{\WF}[2]{{\cal W\!F}(#1)[#2]}
-   \newcommand{\WFE}[1]{\WF{E}{#1}}
-   \newcommand{\WT}[4]{#1[#2] \vdash #3 : #4}
-   \newcommand{\WTE}[3]{\WT{E}{#1}{#2}{#3}}
-   \newcommand{\WTEG}[2]{\WTE{\Gamma}{#1}{#2}}
-
-   \newcommand{\letin}[3]{\kw{let}~#1:=#2~\kw{in}~#3}
-   \newcommand{\subst}[3]{#1\{#2/#3\}}
-
-   \newcommand{\mto}{.\;}
-   \newcommand{\kw}[1]{\textsf{#1}}
-   \newcommand{\lb}{\lambda}
-   \newcommand{\Sort}{\cal S}
-
    \newcommand{\alors}{\textsf{then}}
    \newcommand{\alter}{\textsf{alter}}
    \newcommand{\bool}{\textsf{bool}}
    \newcommand{\conc}{\textsf{conc}}
    \newcommand{\cons}{\textsf{cons}}
    \newcommand{\consf}{\textsf{consf}}
+   \newcommand{\conshl}{\textsf{cons\_hl}}
    \newcommand{\emptyf}{\textsf{emptyf}}
    \newcommand{\EqSt}{\textsf{EqSt}}
+   \newcommand{\even}{\textsf{even}}
+   \newcommand{\evenO}{\textsf{even\_O}}
+   \newcommand{\evenS}{\textsf{even\_S}}
    \newcommand{\false}{\textsf{false}}
    \newcommand{\filter}{\textsf{filter}}
    \newcommand{\forest}{\textsf{forest}}
    \newcommand{\from}{\textsf{from}}
-   \newcommand{\hd}{\textsf{hd}}
    \newcommand{\haslength}{\textsf{has\_length}}
-   \newcommand{\length}{\textsf{length}}
-   \newcommand{\List}{\textsf{list}}
-   \newcommand{\nilhl}{\textsf{nil\_hl}}
-   \newcommand{\conshl}{\textsf{cons\_hl}}
+   \newcommand{\hd}{\textsf{hd}}
    \newcommand{\ident}{\textsf{ident}}
+   \newcommand{\kw}[1]{\textsf{#1}}
+   \newcommand{\lb}{\lambda}
+   \newcommand{\length}{\textsf{length}}
+   \newcommand{\letin}[3]{\kw{let}~#1:=#2~\kw{in}~#3}
+   \newcommand{\List}{\textsf{list}}
+   \newcommand{\mto}{.\;}
    \newcommand{\nat}{\textsf{nat}}
-   \newcommand{\nO}{\textsf{O}}
-   \newcommand{\nS}{\textsf{S}}
-   \newcommand{\node}{\textsf{node}}
    \newcommand{\Nil}{\textsf{nil}}
+   \newcommand{\nilhl}{\textsf{nil\_hl}}
+   \newcommand{\nO}{\textsf{O}}
+   \newcommand{\node}{\textsf{node}}
+   \newcommand{\nS}{\textsf{S}}
+   \newcommand{\odd}{\textsf{odd}}
+   \newcommand{\oddS}{\textsf{odd\_S}}
+   \newcommand{\Pair}{\textsf{pair}}
+   \newcommand{\Prod}{\textsf{prod}}
    \newcommand{\Prop}{\textsf{Prop}}
    \newcommand{\Set}{\textsf{Set}}
    \newcommand{\si}{\textsf{if}}
    \newcommand{\sinon}{\textsf{else}}
+   \newcommand{\Sort}{\cal S}
    \newcommand{\Str}{\textsf{Stream}}
+   \newcommand{\subst}[3]{#1\{#2/#3\}}
    \newcommand{\tl}{\textsf{tl}}
    \newcommand{\tree}{\textsf{tree}}
    \newcommand{\true}{\textsf{true}}
    \newcommand{\Type}{\textsf{Type}}
    \newcommand{\unfold}{\textsf{unfold}}
+   \newcommand{\WF}[2]{{\cal W\!F}(#1)[#2]}
+   \newcommand{\WFE}[1]{\WF{E}{#1}}
+   \newcommand{\WT}[4]{#1[#2] \vdash #3 : #4}
+   \newcommand{\WTE}[3]{\WT{E}{#1}{#2}{#3}}
+   \newcommand{\WTEG}[2]{\WTE{\Gamma}{#1}{#2}}
    \newcommand{\zeros}{\textsf{zeros}}
-   \newcommand{\even}{\textsf{even}}
-   \newcommand{\odd}{\textsf{odd}}
-   \newcommand{\evenO}{\textsf{even\_O}}
-   \newcommand{\evenS}{\textsf{even\_S}}
-   \newcommand{\oddS}{\textsf{odd\_S}}
-   \newcommand{\Prod}{\textsf{prod}}
-   \newcommand{\Pair}{\textsf{pair}}
    \]

--- a/doc/sphinx/replaces.rst
+++ b/doc/sphinx/replaces.rst
@@ -2,98 +2,77 @@
 
 .. role:: smallcaps
 
-.. |Cic| replace:: :smallcaps:`Cic`
-.. |Coq| replace:: :smallcaps:`Coq`
-.. |CoqIDE| replace:: :smallcaps:`CoqIDE`
-.. |Gallina| replace:: :smallcaps:`Gallina`
-.. |Ocaml| replace:: :smallcaps:`OCaml`
-.. |ML| replace:: :smallcaps:`ML`
-
 .. |A_1| replace:: `A`\ :math:`_{1}`
 .. |A_n| replace:: `A`\ :math:`_{n}`
-
 .. |arg_1| replace:: `arg`\ :math:`_{1}`
 .. |arg_n| replace:: `arg`\ :math:`_{n}`
-
+.. |bdi| replace:: :math:`\beta\delta\iota`
 .. |binder_1| replace:: `binder`\ :math:`_{1}`
 .. |binder_n| replace:: `binder`\ :math:`_{n}`
-
 .. |binders_1| replace:: `binders`\ :math:`_{1}`
 .. |binders_n| replace:: `binders`\ :math:`_{n}`
-
+.. |C_1| replace:: `C`\ :math:`_{1}`
 .. |c_1| replace:: `c`\ :math:`_{1}`
+.. |C_2| replace:: `C`\ :math:`_{2}`
 .. |c_i| replace:: `c`\ :math:`_{i}`
 .. |c_n| replace:: `c`\ :math:`_{n}`
-
+.. |Cic| replace:: :smallcaps:`Cic`
 .. |class_1| replace:: `class`\ :math:`_{1}`
 .. |class_2| replace:: `class`\ :math:`_{2}`
-
-.. |C_1| replace:: `C`\ :math:`_{1}`
-.. |C_2| replace:: `C`\ :math:`_{2}`
-
+.. |Coq| replace:: :smallcaps:`Coq`
+.. |CoqIDE| replace:: :smallcaps:`CoqIDE`
 .. |eq_beta_delta_iota_zeta| replace:: `=`\ :math:`_{\small{\beta\delta\iota\zeta}}`
-		   
+.. |Gallina| replace:: :smallcaps:`Gallina`
 .. |ident_0| replace:: `ident`\ :math:`_{0}`
+.. |ident_1,1| replace:: `ident`\ :math:`_{1,1}`
+.. |ident_1,k_1| replace:: `ident`\ :math:`_{1,k_1}`)
 .. |ident_1| replace:: `ident`\ :math:`_{1}`
 .. |ident_2| replace:: `ident`\ :math:`_{2}`
 .. |ident_3| replace:: `ident`\ :math:`_{3}`
 .. |ident_i| replace:: `ident`\ :math:`_{i}`
 .. |ident_j| replace:: `ident`\ :math:`_{j}`
 .. |ident_k| replace:: `ident`\ :math:`_{k}`
-.. |ident_n| replace:: `ident`\ :math:`_{n}`
-
-.. |ident_1,1| replace:: `ident`\ :math:`_{1,1}`
-.. |ident_1,k_1| replace:: `ident`\ :math:`_{1,k_1}`)
 .. |ident_n,1| replace:: `ident`\ :math:`_{n,1}`
 .. |ident_n,k_n| replace:: `ident`\ :math:`_{n,k_n}`
-		       
+.. |ident_n| replace:: `ident`\ :math:`_{n}`
+.. |L_tac| replace:: `L`:sub:`tac`
+.. |ML| replace:: :smallcaps:`ML`
+.. |mod_0| replace:: `mod`\ :math:`_{0}`
+.. |mod_1| replace:: `mod`\ :math:`_{1}`
+.. |mod_2| replace:: `mod`\ :math:`_{1}`
+.. |mod_n| replace:: `mod`\ :math:`_{n}`
 .. |module_0| replace:: `module`\ :math:`_{0}`
 .. |module_1| replace:: `module`\ :math:`_{1}`
-.. |module_n| replace:: `module`\ :math:`_{n}`
-
 .. |module_expression_0| replace:: `module_expression`\ :math:`_{0}`
 .. |module_expression_1| replace:: `module_expression`\ :math:`_{1}`
 .. |module_expression_i| replace:: `module_expression`\ :math:`_{i}`
 .. |module_expression_n| replace:: `module_expression`\ :math:`_{n}`
-
+.. |module_n| replace:: `module`\ :math:`_{n}`
 .. |module_type_0| replace:: `module_type`\ :math:`_{0}`
 .. |module_type_1| replace:: `module_type`\ :math:`_{1}`
 .. |module_type_i| replace:: `module_type`\ :math:`_{i}`
 .. |module_type_n| replace:: `module_type`\ :math:`_{n}`
-
+.. |N| replace:: ``N``
+.. |nat| replace:: ``nat``
+.. |Ocaml| replace:: :smallcaps:`OCaml`
 .. |p_1| replace:: `p`\ :math:`_{1}`
 .. |p_i| replace:: `p`\ :math:`_{i}`
 .. |p_n| replace:: `p`\ :math:`_{n}`
-
+.. |Program| replace:: :strong:`Program`
 .. |t_1| replace:: `t`\ :math:`_{1}`
 .. |t_i| replace:: `t`\ :math:`_{i}`
 .. |t_m| replace:: `t`\ :math:`_{m}`
 .. |t_n| replace:: `t`\ :math:`_{n}`
-
 .. |term_0| replace:: `term`\ :math:`_{0}`
 .. |term_1| replace:: `term`\ :math:`_{1}`
 .. |term_2| replace:: `term`\ :math:`_{2}`
 .. |term_n| replace:: `term`\ :math:`_{n}`
-
 .. |type_0| replace:: `type`\ :math:`_{0}`
 .. |type_1| replace:: `type`\ :math:`_{1}`
 .. |type_2| replace:: `type`\ :math:`_{2}`
 .. |type_3| replace:: `type`\ :math:`_{3}`
 .. |type_n| replace:: `type`\ :math:`_{n}`
-
 .. |x_1| replace:: `x`\ :math:`_{1}`
 .. |x_i| replace:: `x`\ :math:`_{i}`
 .. |x_n| replace:: `x`\ :math:`_{n}`
-
-.. |mod_0| replace:: `mod`\ :math:`_{0}`
-.. |mod_1| replace:: `mod`\ :math:`_{1}`
-.. |mod_2| replace:: `mod`\ :math:`_{1}`
-.. |mod_n| replace:: `mod`\ :math:`_{n}`
-
-.. |Program| replace:: :strong:`Program`
-
-.. |nat| replace:: ``nat``
 .. |Z| replace:: ``Z``
-.. |N| replace:: ``N``
-.. |L_tac| replace:: `L`:sub:`tac`
-.. |bdi| replace:: :math:`\beta\delta\iota`

--- a/doc/tools/coqrst/repl/coqtop.py
+++ b/doc/tools/coqrst/repl/coqtop.py
@@ -50,7 +50,7 @@ class CoqTop:
 
     def next_prompt(self):
         "Wait for the next coqtop prompt, and return the output preceeding it."
-        self.coqtop.expect(CoqTop.COQTOP_PROMPT, timeout = 1)
+        self.coqtop.expect(CoqTop.COQTOP_PROMPT, timeout = 3)
         return self.coqtop.before
 
     def sendone(self, sentence):


### PR DESCRIPTION
**Kind:** documentation

replaces.rst and preamble.tst are alphabetized in order to help avoid duplicates
and to minimize merge conflicts. They are alphabetized first in a case-insensitive
way by the term being defined, and if there are two terms with same case-insensitive
spelling, then by the ascii case-sensitive order. If you insert new items please
put them in the correct order.

The MIGRATING file was updated with a note like the above.

In addition the coqtop timeout was increased from 1 to 3 seconds. I was having trouble
with timeouts when building sphinx.