### PR TITLE
Fix ANTLR warning about extra token

### DIFF
--- a/doc/sphinx/proof-engine/tactics.rst
+++ b/doc/sphinx/proof-engine/tactics.rst
@@ -1232,7 +1232,7 @@ name of the variable (here :g:`n`) is chosen based on :g:`T`.
 
 .. tacv:: generalize {+ @term}
 
-   This is equivalent to :n:`generalize @term; ... ; generalize @term}`.
+   This is equivalent to :n:`generalize @term; ... ; generalize @term`.
    Note that the sequence of term :sub:`i` 's are processed from n to 1.
 
 .. tacv:: generalize @term at {+ @num}


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

There was an ANTLR warning during Sphinx builds:
```
line 1:40 extraneous input '}' expecting <EOF>
```
which was very hard to track down, because the filename isn't given (we have an issue for this). Other users had noted the same warning.

I deleted the extra token.

<!-- Keep what applies -->
**Kind:** bug fix


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->



<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
