### PR TITLE
Add TOC to chapters; clean hierarchies; TOC titleonly

### DIFF
--- a/doc/sphinx/addendum/canonical-structures.rst
+++ b/doc/sphinx/addendum/canonical-structures.rst
@@ -1,14 +1,18 @@
 .. include:: ../replaces.rst
 .. _canonicalstructures:
 
------------------------
- Canonical Structures
------------------------
+Canonical Structures
+======================
+
+:Authors: Assia Mahboubi and Enrico Tassi
 
 :Source: https://coq.inria.fr/distrib/current/refman/canonical-structures.html
 :Converted by: Laurent Théry
 
-Authors : Assia Mahboubi and Enrico Tassi
+.. contents::
+   :local:
+   :depth: 1
+----
 
 This chapter explains the basics of Canonical Structure and how they
 can be used to overload notations and build a hierarchy of algebraic
@@ -21,7 +25,7 @@ presents many techniques one can employ to tune the inference of
 Canonical Structures.
 
 
-19.1 Notation overloading
+Notation overloading
 -------------------------
 
 We build an infix notation == for a comparison predicate. Such
@@ -95,7 +99,7 @@ Similarly, we could equip any other type with a comparison relation,
 and use the ``==`` notation on terms of this type.
 
 
-19.1.1 Derived Canonical Structures
+Derived Canonical Structures
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 We know how to use ``== `` on base types, like ``nat``, ``bool``, ``Z``. Here we show
@@ -132,7 +136,7 @@ for each component of the pair. The declaration associates to the key ``*``
 relation ``pair_eq`` whenever the type constructor ``*`` is applied to two
 types being themselves in the ``EQ`` class.
 
-19.2 Hierarchy of structures
+Hierarchy of structures
 ----------------------------
 
 To get to an interesting example we need another base class to be
@@ -352,7 +356,7 @@ pair constructor preserves this property. The combination of these two
 facts is a simple form of proof search that |Coq| performs automatically
 while inferring canonical structures.
 
-19.2.1 Compact declaration of Canonical Structures
+Compact declaration of Canonical Structures
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 We need some infrastructure for that.

--- a/doc/sphinx/addendum/extended-pattern-matching.rst
+++ b/doc/sphinx/addendum/extended-pattern-matching.rst
@@ -2,16 +2,18 @@
 
 .. _extendedpatternmatching:
 
-==================================================
- Extended pattern-matching (full text)
-==================================================
+Extended pattern-matching
+=========================
+
+:Authors: Cristina Cornes and Hugo Herbelin
 
 :Source: https://coq.inria.fr/distrib/current/refman/cases.html
-:Authors: Cristina Cornes and Hugo Herbelin
 :Converted by: Clément Pit-Claudel
 
 .. contents::
    :local:
+   :depth: 1
+----
 
 .. TODO links to figures
 
@@ -20,7 +22,7 @@ This section describes the full form of pattern-matching in |Coq| terms.
 .. |rhs| replace:: right hand side
 
 Patterns
-========
+--------
 
 The full syntax of match is presented in Figures 1.1 and 1.2.
 Identifiers in patterns are either constructor names or variables. Any
@@ -231,10 +233,10 @@ Here is another example using disjunctive subpatterns.
      end.
 
 About patterns of parametric types
-==================================
+----------------------------------
 
 Parameters in patterns
-----------------------
+~~~~~~~~~~~~~~~~~~~~~~
 
 When matching objects of a parametric type, parameters do not bind in
 patterns. They must be substituted by “``_``”. Consider for example the
@@ -298,7 +300,7 @@ explicitations (as for terms 2.7.11).
 
 
 Matching objects of dependent types
-===================================
+-----------------------------------
 
 The previous examples illustrate pattern matching on objects of non-
 dependent types, but we can also use the expansion strategy to
@@ -313,7 +315,7 @@ lists of a certain length:
 
 
 Understanding dependencies in patterns
-======================================
+--------------------------------------
 
 We can define the function length over :g:`listn` by:
 
@@ -337,10 +339,10 @@ notions of usual pattern matching.
 
 
 When the elimination predicate must be provided
-===============================================
+-----------------------------------------------
 
 Dependent pattern matching
---------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The examples given so far do not need an explicit elimination
 predicate because all the |rhs| have the same type and the strategy
@@ -370,7 +372,7 @@ in the property :g:`Q` in the return clause. The parameters of the
 inductive definitions should not be mentioned and are replaced by ``_``.
 
 Multiple dependent pattern matching
------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Recall that a list of patterns is also a pattern. So, when we
 destructure several terms at the same time and the branches have
@@ -408,7 +410,7 @@ I have a copy of :g:`b` in type :g:`listn 0` resp :g:`listn (S n')`.
 
 
 Patterns in ``in``
-------------------
+~~~~~~~~~~~~~~~~~~
 
 If the type of the matched term is more precise than an inductive
 applied to variables, arguments of the inductive in the ``in`` branch can
@@ -432,7 +434,7 @@ To be concrete: the tail function can be written:
 and :g:`tail n v` will be subterm of :g:`v`.
 
 Using pattern matching to write proofs
-======================================
+--------------------------------------
 
 In all the previous examples the elimination predicate does not depend
 on the object(s) matched. But it may depend and the typical case is
@@ -485,7 +487,7 @@ construction.
 
 
 Pattern-matching on inductive objects involving local definitions
-=================================================================
+-----------------------------------------------------------------
 
 If local definitions occur in the type of a constructor, then there
 are two ways to match on this constructor. Either the local
@@ -532,7 +534,7 @@ can also be caught in the matching.
           there is no mention of it in error messages.
 
 Pattern-matching and coercions
-==============================
+------------------------------
 
 If a mismatch occurs between the expected type of a pattern and its
 actual type, a coercion made from constructors is sought. If such a
@@ -557,8 +559,8 @@ pattern.
                       end).
 
 
-When does the expansion strategy fail ?
-=======================================
+When does the expansion strategy fail?
+--------------------------------------
 
 The strategy works very like in ML languages when treating patterns of
 non-dependent type. But there are new cases of failure that are due to

--- a/doc/sphinx/addendum/extraction.rst
+++ b/doc/sphinx/addendum/extraction.rst
@@ -2,16 +2,18 @@
 
 .. include:: ../replaces.rst
 
--------------------------------------------
 Extraction of programs in OCaml and Haskell
--------------------------------------------
+============================================
 
-:Author: Jean-Christophe Filliâtre and Pierre Letouzey
+:Authors: Jean-Christophe Filliâtre and Pierre Letouzey
+
 :Source: https://coq.inria.fr/distrib/current/refman/extraction.html
 :Converted by: Pierre Letouzey
 
 .. contents::
    :local:
+   :depth: 1
+----
 
 We present here the |Coq| extraction commands, used to build certified
 and relatively efficient functional programs, extracting them from
@@ -31,9 +33,8 @@ directly available without any preliminary ``Require``.
 
    Require Extraction.
 
-
 Generating ML Code
-==================
+-------------------
 
 .. note::
 
@@ -103,10 +104,10 @@ in the |Coq| sources.
    if the current target language of the extraction is not OCaml.
 
 Extraction Options
-==================
+-------------------
 
 Setting the target language
----------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The ability to fix target language is the first and more important
 of the extraction options. Default is ``Ocaml``.
@@ -116,7 +117,7 @@ of the extraction options. Default is ``Ocaml``.
 .. cmd:: Extraction Language Scheme.
 
 Inlining and optimizations
---------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Since OCaml is a strict language, the extracted code has to
 be optimized in order to be efficient (for instance, when using
@@ -213,7 +214,7 @@ reasons, there are two cases:
     declared in the produced file. 
 
 Extra elimination of useless arguments
---------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The following command provides some extra manual control on the
 code elimination performed during extraction, in a way which
@@ -246,7 +247,7 @@ This behavior can be relaxed via the following option:
    depending of the use of these remaining implicited variables.
 
 Realizing axioms
-----------------
+~~~~~~~~~~~~~~~~
 
 Extraction will fail if it encounters an informative axiom not realized. 
 A warning will be issued if it encounters a logical axiom, to remind the
@@ -313,7 +314,7 @@ search these exceptions inside the extracted file and replace them by
 real code.
 
 Realizing inductive types
--------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The system also provides a mechanism to specify ML terms for inductive
 types and constructors. For instance, the user may want to use the ML
@@ -390,7 +391,7 @@ As an example of translation to a non-inductive datatype, let's turn
    Extract Inductive nat => int [ "0" "succ" ] "(fun fO fS n -> if n=0 then fO () else fS (n-1))".
 
 Avoiding conflicts with existing filenames
-------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When using ``Extraction Library``, the names of the extracted files
 directly depends from the names of the |Coq| files. It may happen that
@@ -417,7 +418,7 @@ For OCaml, a typical use of these commands is
 ``Extraction Blacklist String List``.
 
 Differences between |Coq| and ML type systems
-=============================================
+----------------------------------------------
 
 Due to differences between |Coq| and ML type systems, 
 some extracted programs are not directly typable in ML. 
@@ -477,7 +478,7 @@ problems do not occur. For example all the programs of Coq library are
 accepted by Caml type-checker without any ``Obj.magic`` (see examples below).
 
 Some examples
-=============
+-------------
 
 We present here two examples of extractions, taken from the 
 |Coq| Standard Library. We choose OCaml as target language, 
@@ -485,7 +486,7 @@ but all can be done in the other dialects with slight modifications.
 We then indicate where to find other examples and tests of extraction.
 
 A detailed example: Euclidean division
---------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The file ``Euclid`` contains the proof of Euclidean division.
 The natural numbers used there are unary integers of type ``nat``,
@@ -553,13 +554,13 @@ adding these functions to the list of functions to extract. This file
 are meant to help building concrete program via extraction.
 
 Extraction's horror museum
---------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Some pathological examples of extraction are grouped in the file
 ``test-suite/success/extraction.v`` of the sources of \Coq.
 
 Users' Contributions
---------------------
+~~~~~~~~~~~~~~~~~~~~
 
 Several of the |Coq| Users' Contributions use extraction to produce
 certified programs. In particular the following ones have an automatic

--- a/doc/sphinx/addendum/implicit-coercions.rst
+++ b/doc/sphinx/addendum/implicit-coercions.rst
@@ -2,16 +2,21 @@
 
 .. include:: ../replaces.rst
 
----------------------
- Implicit Coercions
----------------------
+Implicit Coercions
+====================
 
 :Author: Amokrane Saïbi
+
 :Source: https://coq.inria.fr/distrib/current/refman/coercions.html
 :Converted by: Pierre Letouzey
 
+.. contents::
+   :local:
+   :depth: 1
+----
+
 General Presentation
-====================
+---------------------
 
 This section describes the inheritance mechanism of |Coq|. In |Coq| with
 inheritance, we are not interested in adding any expressive power to
@@ -28,7 +33,7 @@ typed modulo insertion of appropriate coercions. We allow to write:
 
 
 Classes
-=======
+-------
 
 A class with `n` parameters is any defined name with a type
 :g:`forall (x₁:A₁)..(xₙ:Aₙ),s` where ``s`` is a sort.  Thus a class with
@@ -50,7 +55,7 @@ Formally, the syntax of a classes is defined as:
 
 
 Coercions
-=========
+---------
 
 A name ``f`` can be declared as a coercion between a source user-class
 ``C`` with `n` parameters and a target class ``D`` if one of these
@@ -75,7 +80,7 @@ then an object of ``D``.
 
 
 Identity Coercions
-==================
+-------------------
 
 Identity coercions are special cases of coercions used to go around
 the uniform inheritance condition. Let ``C`` and ``D`` be two classes
@@ -103,7 +108,7 @@ it becomes :g:`C uₙ'..uₖ'` where each ``uᵢ'`` is the result of the
 substitution in ``uᵢ`` of the variables ``xⱼ`` by ``tⱼ``.
 
 Inheritance Graph
-=================
+------------------
 
 Coercions form an inheritance graph with classes as nodes.  We call
 *coercion path* an ordered list of coercions between two nodes of
@@ -123,7 +128,7 @@ term consists of the successive application of its coercions.
 
 
 Declaration of Coercions
-========================
+-------------------------
 
 .. cmd:: Coercion @qualid : @class >-> @class.
 
@@ -234,7 +239,7 @@ declaration, this constructor is declared as a coercion.
 
 
 Displaying Available Coercions
-==============================
+-------------------------------
 
 .. cmd:: Print Classes.
 
@@ -253,7 +258,7 @@ Displaying Available Coercions
   Print the list of valid coercion paths between the two given classes.
 
 Activating the Printing of Coercions
-====================================
+-------------------------------------
 
 .. cmd:: Set Printing Coercions.
 
@@ -269,7 +274,7 @@ Activating the Printing of Coercions
 
 
 Classes as Records
-==================
+------------------
 
 We allow the definition of *Structures with Inheritance* (or
 classes as records) by extending the existing ``Record`` macro
@@ -299,7 +304,7 @@ FIXME: \comindex{Structure}
 
 
 Coercions and Sections
-======================
+----------------------
 
 The inheritance mechanism is compatible with the section
 mechanism. The global classes and coercions defined inside a section
@@ -311,7 +316,7 @@ coercions which do not verify the uniform inheritance condition any longer
 are also forgotten.
 
 Coercions and Modules
-=====================
+--------------------=
 
 From |Coq| version 8.3, the coercions present in a module are activated
 only when the module is explicitly imported. Formerly, the coercions
@@ -327,12 +332,12 @@ To cancel the effect of the option, use instead ``Unset Automatic Coercions Impo
 
 
 Examples
-========
+--------
 
 There are three situations:
 
 Coercion at function application
---------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :g:`f a` is ill-typed where :g:`f:forall x:A,B` and :g:`a:A'`. If there is a
 coercion path between ``A'`` and ``A``, then :g:`f a` is transformed into
@@ -417,7 +422,7 @@ previous example.
 
 
 Coercion to a type
-------------------
+~~~~~~~~~~~~~~~~~~
 
 An assumption ``x:A`` when ``A`` is not a type, is ill-typed.  It is
 replaced by ``x:A'`` where ``A'`` is the result of the application to
@@ -444,7 +449,7 @@ to ``B`` also if necessary.
 
 
 Coercion to a function
-----------------------
+~~~~~~~~~~~~~~~~~~~~~~
 
 ``f a`` is ill-typed because ``f:A`` is not a function. The term
 ``f`` is replaced by the term obtained by applying to ``f`` the

--- a/doc/sphinx/addendum/micromega.rst
+++ b/doc/sphinx/addendum/micromega.rst
@@ -1,17 +1,20 @@
 .. _ micromega:
 
---------------------------------------------------------------------
- Micromega: tactics for solving arithmetic goals over ordered rings
---------------------------------------------------------------------
+Micromega: tactics for solving arithmetic goals over ordered rings
+=======
+
+:Authors: Frédéric Besson and Evgeny Makarov
 
 :Source: https://coq.inria.fr/distrib/current/refman/micromega.html
 :Converted by: Paul Steckler
 
-Authors: Frédéric Besson and Evgeny Makarov
-
+.. contents::
+   :local:
+   :depth: 1
+----
 
 Short description of the tactics
--------------------------------------
+--------------------------------
 
 The Psatz module (``Require Import Psatz.``) gives access to several
 tactics for solving arithmetic goals over :math:`\mathbb{Z}`, :math:`\mathbb{Q}`, and :math:`\mathbb{R}` [#]_.
@@ -61,7 +64,7 @@ This includes integer constants written using the decimal notation, *i.e.*, c%R.
 
 
 *Positivstellensatz* refutations
--------------------------------------
+--------------------------------
 
 The name `psatz` is an abbreviation for *positivstellensatz* – literally
 "positivity theorem" – which generalizes Hilbert’s *nullstellensatz*. It
@@ -99,7 +102,7 @@ and checked to be :math:`-1`.
 .. _lra:
 
 `lra`: a decision procedure for linear real and rational arithmetic
-----------------------------------------------------------------------
+-------------------------------------------------------------------
 
 The `lra` tactic is searching for *linear* refutations using Fourier
 elimination [#]_. As a result, this tactic explores a subset of the *Cone*
@@ -115,7 +118,7 @@ tactic *e.g.*, :math:`x = 10 * x / 10` is solved by `lra`.
 .. _lia:
 
 `lia`: a tactic for linear integer arithmetic
-------------------------------------------------
+---------------------------------------------
 
 The tactic lia offers an alternative to the omega and romega tactic
 (see :ref:`omega`). Roughly speaking, the deductive power of lia is
@@ -133,7 +136,7 @@ The estimation of the relative efficiency of `lia` *vs* `omega` and `romega`
 is under evaluation.
 
 High level view of `lia`
-++++++++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 Over :math:`\mathbb{R}`, *positivstellensatz* refutations are a complete proof
 principle [#]_. However, this is not the case over :math:`\mathbb{Z}`. Actually,
@@ -147,7 +150,7 @@ weakness, the `lia` tactic is using recursively a combination of:
 + case split.
   
 Cutting plane proofs
-+++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~~~
 
 are a way to take into account the discreteness of :math:`\mathbb{Z}` by rounding up
 (rational) constants up-to the closest integer.
@@ -171,7 +174,7 @@ Cutting plane proofs and linear *positivstellensatz* refutations are a
 complete proof principle for integer linear arithmetic.
 
 Case split
-++++++++++++
+~~~~~~~~~~~
 
 enumerates over the possible values of an expression.
 
@@ -190,7 +193,7 @@ a proof.
 .. _nra:
 
 `nra`: a proof procedure for non-linear arithmetic
------------------------------------------------------
+--------------------------------------------------
 
 The `nra` tactic is an *experimental* proof procedure for non-linear
 arithmetic. The tactic performs a limited amount of non-linear
@@ -210,7 +213,7 @@ proof by abstracting monomials by variables.
 .. _nia:
 
 `nia`: a proof procedure for non-linear integer arithmetic
--------------------------------------------------------------
+----------------------------------------------------------
 
 The `nia` tactic is a proof procedure for non-linear integer arithmetic.
 It performs a pre-processing similar to `nra`. The obtained goal is
@@ -219,7 +222,7 @@ solved using the linear integer prover `lia`.
 .. _psatz:
 
 `psatz`: a proof procedure for non-linear arithmetic
--------------------------------------------------------
+----------------------------------------------------
 
 The `psatz` tactic explores the :math:`\mathit{Cone}` by increasing degrees – hence the
 depth parameter :math:`n`. In theory, such a proof search is complete – if the

--- a/doc/sphinx/addendum/nsatz.rst
+++ b/doc/sphinx/addendum/nsatz.rst
@@ -2,14 +2,18 @@
 
 .. _nsatz:
 
------------------------------------------------------------
- Nsatz: tactics for proving equalities in integral domains
------------------------------------------------------------
+Nsatz: tactics for proving equalities in integral domains
+===========================================================
+
+:Author: Loïc Pottier
 
 :Source: https://coq.inria.fr/distrib/current/refman/nsatz.html
 :Converted by: Paul Steckler
 
-Author: Loïc Pottier
+.. contents::
+   :local:
+   :depth: 1
+----
 
 The tactic `nsatz` proves goals of the form
 

--- a/doc/sphinx/addendum/omega.rst
+++ b/doc/sphinx/addendum/omega.rst
@@ -1,15 +1,20 @@
 .. _omega:
 
------------------------------------------------------------------------
- Omega: a solver for quantifier-free problems in Presburger Arithmetic
------------------------------------------------------------------------
+Omega: a solver for quantifier-free problems in Presburger Arithmetic
+=======
 
 :Author: Pierre Crégut
+
 :Source: https://coq.inria.fr/distrib/current/refman/omega.html
 :Converted by: Pierre Letouzey
 
+.. contents::
+   :local:
+   :depth: 1
+----
+
 Description of ``omega``
-========================
+------------------------
 
 This tactic does not need any parameter:
 
@@ -87,7 +92,7 @@ is generated:
 
 
 Using ``omega``
-===============
+---------------
 
 The ``omega`` tactic does not belong to the core system. It should be
 loaded by
@@ -114,10 +119,10 @@ loaded by
 
 
 Technical data
-==============
+--------------
 
 Overview of the tactic
-----------------------
+~~~~~~~~~~~~~~~~~~~~~~
 
  * The goal is negated twice and the first negation is introduced as an hypothesis.
  * Hypothesis are decomposed in simple equations or inequations. Multiple
@@ -129,7 +134,7 @@ Overview of the tactic
  * The script of the solution is replayed.
 
 Overview of the OMEGA decision procedure
-----------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The OMEGA decision procedure involved in the ``omega`` tactic uses
 a small subset of the decision procedure presented in :cite:`TheOmegaPaper`
@@ -156,7 +161,7 @@ steps of the Omega procedure (dark shadow) are not implemented, so the
 decision procedure is only partial.
 
 Bugs
-====
+----
 
  * The simplification procedure is very dumb and this results in
    many redundant cases to explore.

--- a/doc/sphinx/addendum/parallel-proof-processing.rst
+++ b/doc/sphinx/addendum/parallel-proof-processing.rst
@@ -2,14 +2,18 @@
 
 .. _asynchronousandparallelproofprocessing:
 
+Asynchronous and Parallel Proof Processing
+==========================================
+
+:Author: Enrico Tassi
+
 :Source: https://coq.inria.fr/distrib/current/refman/async-proofs.html
 :Converted by: Paul Steckler
 
-------------------------------------------
-Asynchronous and Parallel Proof Processing
-------------------------------------------
-
-Author: Enrico Tassi
+.. contents::
+   :local:
+   :depth: 1
+----
 
 This chapter explains how proofs can be asynchronously processed by
 |Coq|. This feature improves the reactivity of the system when used in

--- a/doc/sphinx/addendum/program.rst
+++ b/doc/sphinx/addendum/program.rst
@@ -5,16 +5,18 @@
 
 .. _programs:
 
-----------
 Program
-----------
+========
 
 :Author: Matthieu Sozeau
+
 :Converted by: Matthieu Sozeau
 :Source: https://coq.inria.fr/distrib/current/refman/program.html
 
 .. contents::
    :local:
+   :depth: 1
+----
 
 We present here the |Program| tactic commands, used to build
 certified |Coq| programs, elaborating them from their algorithmic
@@ -42,7 +44,7 @@ obligations which need to be resolved to create the final term.
 .. _elaborating-programs:
 
 Elaborating programs
-====================
+---------------------
 
 The main difference from |Coq| is that an object in a type T : Set can
 be considered as an object of type { x : T | P} for any wellformed P :
@@ -276,7 +278,7 @@ Program Lemma
 .. _solving_obligations:
 
 Solving obligations
-===================
+--------------------
 
 The following commands are available to manipulate obligations. The
 optional identifier is used when multiple functions have unsolved
@@ -353,7 +355,7 @@ adds some useful notations, as documented in the file itself.
 .. _program-faq:
 
 Frequently Asked Questions
-==========================
+---------------------------
 
 
 .. exn:: Ill-formed recursive definition

--- a/doc/sphinx/addendum/ring.rst
+++ b/doc/sphinx/addendum/ring.rst
@@ -3,15 +3,18 @@
 
 .. _theringandfieldtacticfamilies:
 
-------------------------------------
- The ring and field tactic families
-------------------------------------
+The ring and field tactic families
+====================================
+
+:Author: Bruno Barras, Benjamin Grégoire, Assia Mahboubi, Laurent Théry [#f1]_
 
 :Source: https://coq.inria.fr/distrib/current/refman/ring.html
 :Converted by: Laurent Théry
 
-Authors : Bruno Barras, Benjamin Grégoire, Assia Mahboubi, Laurent Théry [#f1]_
-
+.. contents::
+   :local:
+   :depth: 1
+----
 
 This chapter presents the tactics dedicated to deal with ring and
 field equations.

--- a/doc/sphinx/addendum/universe-polymorphism.rst
+++ b/doc/sphinx/addendum/universe-polymorphism.rst
@@ -2,19 +2,21 @@
 
 .. _polymorphicuniverses:
 
-==================================
- Polymorphic Universes
-==================================
+Polymorphic Universes
+======================
 
 :Author: Matthieu Sozeau
+
 :Converted by: Clément Pit-Claudel
 :Source: https://coq.inria.fr/distrib/current/refman/universes.html
 
 .. contents::
    :local:
+   :depth: 1
+----
 
 General Presentation
-====================
+---------------------
 
 .. warning::
 
@@ -122,7 +124,7 @@ As one can see from the constraints, this monoid is “large”, it lives
 in a universe strictly higher than :g:`Set`.
 
 Polymorphic, Monomorphic
-========================
+-------------------------
 
 .. cmd:: Polymorphic @definition
 
@@ -161,7 +163,7 @@ Many other commands support the ``Polymorphic`` flag, including:
 
 
 Global and local universes
-==========================
+---------------------------
 
 Each universe is declared in a global or local environment before it
 can be used. To ensure compatibility, every *global* universe is set
@@ -171,7 +173,7 @@ greater or equal to :g:`Set`.
 
 
 Conversion and unification
-==========================
+---------------------------
 
 The semantics of conversion and unification have to be modified a
 little to account for the new universe instance arguments to
@@ -193,7 +195,7 @@ the same development with universe polymorphism switched on or off.
 
 
 Minimization
-============
+-------------
 
 Universe polymorphism with cumulativity tends to generate many useless
 inclusion constraints in general. Typically at each application of a
@@ -225,7 +227,7 @@ it is an atomic universe (i.e. not an algebraic max() universe).
 
 
 Explicit Universes
-==================
+-------------------
 
 The syntax has been extended to allow users to explicitly bind names
 to universes and explicitly instantiate polymorphic definitions.
@@ -252,7 +254,7 @@ to universes and explicitly instantiate polymorphic definitions.
 
 
 Polymorphic definitions
------------------------
+~~~~~~~~~~~~~~~~~~~~~~~
 
 For polymorphic definitions, the declaration of (all) universe levels
 introduced by a definition uses the following syntax:

--- a/doc/sphinx/index.rst
+++ b/doc/sphinx/index.rst
@@ -1337,7 +1337,7 @@ Table of contents
 
 .. toctree::
    :caption: The language
-   :maxdepth: 10
+   :titlesonly:
 
    language/gallina-specification-language
    language/gallina-extensions
@@ -1347,7 +1347,7 @@ Table of contents
 
 .. toctree::
    :caption: The proof engine
-   :maxdepth: 10
+   :titlesonly:
 
    proof-engine/vernacular-commands
    proof-engine/proof-handling
@@ -1358,14 +1358,14 @@ Table of contents
 
 .. toctree::
    :caption: User extensions
-   :maxdepth: 10
+   :titlesonly:
 
    user-extensions/syntax-extensions
    user-extensions/proof-schemes
 
 .. toctree::
    :caption: Practical tools
-   :maxdepth: 10
+   :titlesonly:
 
    practical-tools/coq-commands
    practical-tools/utilities
@@ -1373,7 +1373,7 @@ Table of contents
 
 .. toctree::
    :caption: Addendum
-   :maxdepth: 10
+   :titlesonly:
 
    addendum/extended-pattern-matching
    addendum/implicit-coercions
@@ -1392,7 +1392,7 @@ Table of contents
 
 .. toctree::
    :caption: Reference
-   :maxdepth: 10
+   :titlesonly:
 	     
    glossary
 
@@ -1400,7 +1400,7 @@ Table of contents
 
 .. toctree::
    :caption: Indexes
-   :maxdepth: 10
+   :titlesonly:
 	     
    genindex
    coq-cmdindex

--- a/doc/sphinx/language/gallina-extensions.rst
+++ b/doc/sphinx/language/gallina-extensions.rst
@@ -8,6 +8,11 @@ Extensions of |Gallina|
 :Source: https://coq.inria.fr/distrib/current/refman/gallina-ext.html
 :Converted by: Paul Steckler
 
+.. contents::
+   :local:
+   :depth: 1
+----
+
 |Gallina| is the kernel language of |Coq|. We describe here extensions of
 |Gallina|’s syntax.
 

--- a/doc/sphinx/language/module-system.rst
+++ b/doc/sphinx/language/module-system.rst
@@ -3,16 +3,16 @@
 
 .. _themodulesystem:
 
+The Module System
+=================
+
 :Source: https://coq.inria.fr/distrib/current/refman/modules.html
 :Converted by: Richard L. Ford
 
 .. contents::
    :local:
-   :depth: 2
-
-
-The Module System
-===========================
+   :depth: 1
+----
 
 The module system extends the Calculus of Inductive Constructions
 providing a convenient way to structure large developments as well as
@@ -21,7 +21,6 @@ a means of massive abstraction.
 
 Modules and module types
 ----------------------------
-
 
 **Access path.** An access path is denoted by :math:`p` and can be
 either a module variable :math:`X` or, if :math:`p′` is an access path

--- a/doc/sphinx/practical-tools/coq-commands.rst
+++ b/doc/sphinx/practical-tools/coq-commands.rst
@@ -2,12 +2,16 @@
 
 .. _thecoqcommands:
 
--------------------
- The |Coq| commands
--------------------
+The |Coq| commands
+====================
 
 :Source: https://coq.inria.fr/distrib/current/refman/commands.html
 :Converted by: Paul Steckler
+
+.. contents::
+   :local:
+   :depth: 1
+------------
 
 There are three |Coq| commands:
 
@@ -68,8 +72,8 @@ directories to the load path of |Coq|. It is possible to skip the
 loading of the resource file with the option `-q`.
 
 
-14.3.2 By environment variables
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+By environment variables
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Load path can be specified to the |Coq| system by setting up `$COQPATH`
 environment variable. It is a list of directories separated by

--- a/doc/sphinx/practical-tools/coqide.rst
+++ b/doc/sphinx/practical-tools/coqide.rst
@@ -2,12 +2,16 @@
 
 .. _coqintegrateddevelopmentenvironment:
 
-----------------------------------------
 |Coq| Integrated Development Environment
-----------------------------------------
+========================================
 
 :Source: https://coq.inria.fr/distrib/current/refman/coqide.html
 :Converted by: Paul Steckler
+
+.. contents::
+   :local:
+   :depth: 1
+----
 
 The Coq Integrated Development Environment is a graphical tool, to be
 used as a user-friendly replacement to `coqtop`. Its main purpose is to

--- a/doc/sphinx/proof-engine/detailed-tactic-examples.rst
+++ b/doc/sphinx/proof-engine/detailed-tactic-examples.rst
@@ -6,6 +6,11 @@ Detailed examples of tactics
 :Source: https://coq.inria.fr/distrib/current/refman/tactic-examples.html
 :Converted by: Calvin Beck
 
+.. contents::
+   :local:
+   :depth: 1
+----
+
 This chapter presents detailed examples of certain tactics, to
 illustrate their behavior.
 

--- a/doc/sphinx/proof-engine/tactics.rst
+++ b/doc/sphinx/proof-engine/tactics.rst
@@ -4,10 +4,15 @@
 .. _tactics:
 
 Tactics
-==============================
+=======
 
 :Source: https://coq.inria.fr/distrib/current/refman/tactics.html
 :Converted by: Heiko Becker and Nikita Zyuzin
+
+.. contents::
+   :local:
+   :depth: 1
+----
 
 A deduction rule is a link between some (unique) formula, that we call
 the *conclusion* and (several) formulas that we call the *premises*. A

--- a/doc/sphinx/user-extensions/proof-schemes.rst
+++ b/doc/sphinx/user-extensions/proof-schemes.rst
@@ -1,11 +1,15 @@
 .. _proofschemes:
 
--------------------
- Proof schemes
--------------------
+Proof schemes
+===============
 
 :Source: https://coq.inria.fr/distrib/current/refman/schemes.html
 :Converted by: Paul Steckler
+
+.. contents::
+   :local:
+   :depth: 1
+----
 
 Generation of induction principles with ``Scheme``
 --------------------------------------------------------
@@ -163,8 +167,8 @@ concluded by the conjunction of their conclusions.
 
     Check tree_forest_mutind.
 
-Generation of induction principles with Functional Scheme
-----------------------------------------------------------
+Generation of induction principles with ``Functional`` ``Scheme``
+-----------------------------------------------------------------
 
 The ``Functional Scheme`` command is a high-level experimental tool for
 generating automatically induction principles corresponding to
@@ -306,10 +310,10 @@ definition written by the user.
 
     Check tree_size_ind2.
      
-Generation of inversion principles with ``Derive Inversion``
---------------------------------------------------------------
+Generation of inversion principles with ``Derive`` ``Inversion``
+-----------------------------------------------------------------
 
-The syntax of ``Derive Inversion`` follows the schema:
+The syntax of ``Derive`` ``Inversion`` follows the schema:
 
 .. cmd:: Derive Inversion ident with forall (x : T), I t Sort sort
 

--- a/doc/sphinx/user-extensions/syntax-extensions.rst
+++ b/doc/sphinx/user-extensions/syntax-extensions.rst
@@ -1,11 +1,15 @@
 .. _syntaxextensionsandinterpretationscopes:
 
-========================================================
- Syntax extensions and interpretation scopes
+Syntax extensions and interpretation scopes
 ========================================================
 
 :Source: https://coq.inria.fr/distrib/current/refman/syntax-extensions.html
 :Converted by: Clément Pit-Claudel
+
+.. contents::
+   :local:
+   :depth: 1
+----
 
 In this chapter, we introduce advanced commands to modify the way Coq
 parses and prints objects, i.e. the translations between the concrete
@@ -26,10 +30,10 @@ interpretation scope. This is described in Section 12.2.
    Set Printing Depth 50.
 
 Notations
-=========
+---------
 
 Basic notations
----------------
+~~~~~~~~~~~~~~~
 
 A *notation* is a symbolic abbreviation denoting some term or term
 pattern.
@@ -68,7 +72,7 @@ have to be given.
 
 
 Precedences and associativity
------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Mixing different symbolic notations in a same text may cause serious
 parsing ambiguity. To deal with the ambiguity of notations, Coq uses
@@ -120,7 +124,7 @@ Figure 3.1.
 .. TODO I don't find it obvious -- CPC
 
 Complex notations
------------------
+~~~~~~~~~~~~~~~~~
 
 Notations can be made from arbitrarily complex symbols. One can for
 instance define prefix notations.
@@ -162,7 +166,7 @@ correct definition is
 See the next section for more about factorization.
 
 Simple factorization rules
---------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Coq extensible parsing is performed by *Camlp5* which is essentially a
 LL1 parser. Hence, some care has to be taken not to hide already
@@ -202,7 +206,7 @@ predefined notations can be found in Chapter 3.
 
 
 Displaying symbolic notations
------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The command ``Notation`` has an effect both on the Coq parser and on the
 Coq printer. For example:
@@ -293,7 +297,7 @@ at the time of use of the notation.
           of ``Notation``.
 
 The Infix command
------------------
+~~~~~~~~~~~~~~~~~~
 
 The ``Infix`` command is a shortening for declaring notations of infix
 symbols.
@@ -312,7 +316,7 @@ symbols.
       Infix "/\" := and (at level 80, right associativity).
 
 Reserving notations
--------------------
+~~~~~~~~~~~~~~~~~~~
 
 A given notation may be used in different contexts. Coq expects all
 uses of the notation to be defined at the same precedence and with the
@@ -332,7 +336,7 @@ inductive type or a recursive constant and a notation for it.
           their precedence and associativity cannot be changed.
 
 Simultaneous definition of terms and notations
-----------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Thanks to reserved notations, the inductive, co-inductive, recursive
 and corecursive definitions can benefit of customized notations. To do
@@ -354,7 +358,7 @@ on Figure 12.1. Here are examples:
    where "n + m" := (plus n m).
 
 Displaying informations about notations
----------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. opt:: Printing Notations
 
@@ -370,7 +374,7 @@ Displaying informations about notations
       To disable other elements in addition to notations.
 
 Locating notations
-------------------
+~~~~~~~~~~~~~~~~~~
 
 .. cmd:: Locate @symbol
 
@@ -388,7 +392,7 @@ Locating notations
    .. todo:: See also: Section 6.3.10.
 
 Notations and simple binders
-----------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Notations can be defined for binders as in the example:
 
@@ -425,7 +429,7 @@ the next command fails because p does not bind in the instance of n.
 
 
 Notations with recursive patterns
----------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A mechanism is provided for declaring elementary notations with
 recursive patterns. The basic example is:
@@ -479,7 +483,7 @@ section 12.2).
 
 
 Notations with recursive patterns involving binders
----------------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Recursive notations can also be used with binders. The basic example
 is:
@@ -522,7 +526,7 @@ example of recursive notation with closed binders:
      (x closed binder, y closed binder, at level 200, right associativity).
 
 Summary
--------
+~~~~~~~
 
 Syntax of notations
 ~~~~~~~~~~~~~~~~~~~
@@ -584,7 +588,7 @@ Notations do not survive the end of sections.
    of ``Notation``.
 
 Interpretation scopes
-=====================
+----------------------
 
 An *interpretation scope* is a set of notations for terms with their
 interpretation. Interpretation scopes provides with a weak, purely
@@ -608,7 +612,7 @@ declares the notation for conjunction in the scope ``type_scope``.
           notation.
 
 Global interpretation rules for notations
------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 At any time, the interpretation of a notation for term is done within
 a *stack* of interpretation scopes and lonely notations. In case a
@@ -658,13 +662,13 @@ lonely notations. These scopes, in opening order, are ``core_scope``,
    not inside a section.
 
 Local interpretation rules for notations
-----------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 In addition to the global rules of interpretation of notations, some
 ways to change the interpretation of subterms are available.
 
 Local opening of an interpretation scope
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
++++++++++++++++++++++++++++++++++++++++++
 
 It is possible to locally extend the interpretation scope stack using the syntax
 :g:`(term)%key` (or simply :g:`term%key` for atomic terms), where key is a
@@ -684,7 +688,7 @@ interpreted in the scope stack extended with the scope bound tokey.
    :n:`Undelimit Scope @scope`
 
 Binding arguments of a constant to an interpretation scope
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. cmd:: Arguments @qualid {+ @name%@scope}
 
@@ -742,7 +746,7 @@ Binding arguments of a constant to an interpretation scope
      function is described in Section 2.
 
 Binding types of arguments to an interpretation scope
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. cmd:: Bind Scope @scope with @qualid
 
@@ -788,7 +792,7 @@ Binding types of arguments to an interpretation scope
      function is described in Section 2.
 
 The ``type_scope`` interpretation scope
----------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The scope ``type_scope`` has a special status. It is a primitive
 interpretation scope which is temporarily activated each time a
@@ -798,7 +802,7 @@ codomain of products, and more generally any type argument of a
 declared or defined constant.
 
 Interpretation scopes used in the standard library of Coq
----------------------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 We give an overview of the scopes used in the standard library of Coq.
 For a complete list of notations in each scope, use the commands Print
@@ -885,7 +889,7 @@ Scopes or Print Scope scope.
 
 
 Displaying informations about scopes
-------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. cmd:: Print Visibility
 
@@ -915,7 +919,7 @@ Displaying informations about scopes
    lonely notations.
 
 Abbreviations
-=============
+--------------
 
 .. cmd:: {? Local} Notation @ident {+ @ident} := @term {? (only parsing)}.
 
@@ -977,7 +981,7 @@ Abbreviations
    done only at the time of use of the abbreviation.
 
 Tactic Notations
-================
+-----------------
 
 Tactic notations allow to customize the syntax of the tactics of the
 tactic language [#tacn]_. Tactic notations obey the following syntax:


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

I added the per-chapter table of contents to each chapter, like in the TeX version of the manual. In each chapoter, the TOC is separated from the following text by an underline, which I think looks nice.

Also, I tried to make the underlining hierarchies uniform for all chapters, to make those TOCs look right.

I made the TOC in the side panel `:titlesonly:` (it was `:maxdepth: 10`), because it looked pretty cluttered to have the entire hierarchy exposed there, and clumsy to navigate. Others may disagree.

There are other little bits of cleanup, too.

<!-- Keep what applies -->
**Kind:** documentation


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->


<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
